### PR TITLE
added `sourceFile` and `program` options to parse

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -34,7 +34,7 @@
     for (var opt in defaultOptions) if (!options.hasOwnProperty(opt))
       options[opt] = defaultOptions[opt];
     sourceFile = options.sourceFile || null;
-    return parseTopLevel(opts.program);
+    return parseTopLevel(options.program);
   };
 
   // A second optional argument can be given to further configure


### PR DESCRIPTION
- if `program` is given, it'll be used as the toplevel node, instead of
  creating a new node, and statements will be added to its body
- if `sourceFile` is given and `locations` is on, it'll set the `source`
  property in every node's `loc`.

closes #5.
