### PR TITLE
make the 3 "Literal"s have 'raw' property

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -1481,6 +1481,7 @@
     case _null: case _true: case _false:
       var node = startNode();
       node.value = tokType.atomValue;
+      node.raw = tokType.keyword
       next();
       return finishNode(node, "Literal");
 


### PR DESCRIPTION
In the generated ast, "null"/"true"/"false" are "Literal" nodes.
As every "Literal" node has a 'raw' property,
When i am doing something with the ast using python,
the 3 "Literal"s caused some problem.
make the 3 "Literal"s have 'raw' property.
