### PR TITLE
Fixes sourceFile option.

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -895,8 +895,8 @@
   var node_loc_t = function(s) {
     this.start=tokStartLoc;
     this.end=null;
+    if (sourceFile !== null) this.source=sourceFile;
   };
-  node_loc_t.prototype.source=sourceFile;
 
   function startNode() {
     var node = new node_t();

--- a/test/tests.js
+++ b/test/tests.js
@@ -26065,6 +26065,100 @@ test("foo: 10; foo: 20;", {
   ]
 });
 
+// option tests
+
+test("var a = 1;", {
+  "type": "Program",
+  "start": 0,
+  "end": 10,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 10
+    },
+    "source": "test.js"
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "start": 0,
+      "end": 9,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 9
+        },
+        "source": "test.js"
+      },
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "start": 4,
+          "end": 9,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 4
+            },
+            "end": {
+              "line": 1,
+              "column": 9
+            },
+            "source": "test.js"
+          },
+          "id": {
+            "type": "Identifier",
+            "start": 4,
+            "end": 5,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              },
+              "source": "test.js"
+            },
+            "name": "a"
+          },
+          "init": {
+            "type": "Literal",
+            "start": 8,
+            "end": 9,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 8
+              },
+              "end": {
+                "line": 1,
+                "column": 9
+              },
+              "source": "test.js"
+            },
+            "value": 1,
+            "raw": "1"
+          }
+        }
+      ],
+      "kind": "var"
+    }
+  ]
+}, {
+  locations: true,
+  sourceFile: "test.js"
+})
+
 // Failure tests
 
 testFail("{",


### PR DESCRIPTION
When setting the .prototype.source the sourceFile variable is undefined, and
setting the sourceFile option doesn't change the .source property on the
prototype anymore.

By setting the .source property inside the node_loc_t constructor, the correct
sourceFile is set in the loc object.
