### PR TITLE
Add testAssert() for arbitrary tests; fix skipLineComments() off-by-1

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -497,7 +497,7 @@
       ch = input.charCodeAt(tokPos);
     }
     if (options.onComment)
-      options.onComment(false, input.slice(start + 2, tokPos - 1), start, tokPos,
+      options.onComment(false, input.slice(start + 2, tokPos), start, tokPos,
                         startLoc, options.locations && curLineLoc());
   }
 

--- a/test/driver.js
+++ b/test/driver.js
@@ -8,6 +8,9 @@
   exports.testFail = function(code, message, options) {
     tests.push({code: code, error: message, options: options});
   };
+  exports.testAssert = function(code, assert, options) {
+    tests.push({code: code, assert: assert, options: options});
+  };
 
   exports.runTests = function(callback) {
     var opts = {locations: true};
@@ -17,7 +20,12 @@
         var ast = acorn.parse(test.code, test.options || opts);
         if (test.error) callback("fail", test.code,
                                  "Expected error message: " + test.error + "\nBut parsing succeeded.");
-        else {
+        else if (test.assert) {
+          var error = test.assert(ast);
+          if (error) callback("fail", test.code,
+                                 "\n  Assertion failed:\n " + error);
+          else callback("ok", test.code);
+        } else {
           var mis = misMatch(test.ast, ast);
           if (!mis) callback("ok", test.code);
           else callback("fail", test.code, mis);

--- a/test/tests.js
+++ b/test/tests.js
@@ -4,6 +4,7 @@
 if (typeof exports != "undefined") {
   var test = require("./driver.js").test;
   var testFail = require("./driver.js").testFail;
+  var testAssert = require("./driver.js").testAssert;
 }
 
 test("this\n", {
@@ -26716,3 +26717,55 @@ testFail("(function a(package) { \"use strict\"; })",
 testFail("var this = 10;", "Unexpected token (1:4)");
 
 testFail("throw\n10;", "Illegal newline after throw (1:5)");
+
+// Assertion Tests
+(function() {
+  var actualComments = [],
+      expectedComments = [
+        " Bear class",
+        " Whatever",
+        [" 1",
+         "         2",
+         "         3"
+        ].join('\n'),
+        "stuff"
+      ];
+  testAssert(
+    function TestComments() {
+      // Bear class
+      function Bear(x,y,z) {
+        this.position = [x||0,y||0,z||0]
+      }
+
+      Bear.prototype.roar = function(message) {
+        return 'RAWWW: ' + message; // Whatever
+      };
+
+      function Cat() {
+      /* 1
+         2
+         3*/
+      }
+
+      Cat.prototype.roar = function(message) {
+        return 'MEOOWW: ' + /*stuff*/ message;
+      };
+    }.toString(),
+    function assert(ast) {
+      if (actualComments.length !== expectedComments.length) {
+        return JSON.stringify(actualComments) + " !== " + JSON.stringify(expectedComments);
+      } else {
+        for (var i=0, n=actualComments.length; i < n; i++) {
+          if (actualComments[i] !== expectedComments[i])
+            return JSON.stringify(actualComments[i]) + ' !== ' + JSON.stringify(expectedComments[i]);
+        }
+      }
+    },
+    {
+      onComment: function(isMultiline, text) {
+        actualComments.push(text);
+      }
+    }
+  );
+})();
+  


### PR DESCRIPTION
Add testAssert() for arbitrary tests; fix skipLineComments() passing off-by-1 character to onComment(slice(.., end))

Example of the off-by-1 error:

```
function TestComments() {
      // Bear class
      function Bear(x,y,z) {
        this.position = [x||0,y||0,z||0]
      }

      Bear.prototype.roar = function(message) {
        return 'RAWWW: ' + message; // Whatever
      };

      function Cat() {
      /* 1
         2
         3*/
      }

      Cat.prototype.roar = function(message) {
        return 'MEOOWW: ' + /*stuff*/ message;
      };
    }
  Assertion failed:
 " Bear clas" !== " Bear class"
502 tests run in 59ms
1 failures.
```
