### PR TITLE
Fix \v being treated as v in IE < 9

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -826,7 +826,7 @@
           case 85: out += String.fromCharCode(readHexChar(8)); break; // 'U'
           case 116: out += "\t"; break; // 't' -> '\t'
           case 98: out += "\b"; break; // 'b' -> '\b'
-          case 118: out += "\v"; break; // 'v' -> '\u000b'
+          case 118: out += "\u000b"; break; // 'v' -> '\u000b'
           case 102: out += "\f"; break; // 'f' -> '\f'
           case 48: out += "\0"; break; // 0 -> '\0'
           case 13: if (input.charCodeAt(tokPos) === 10) ++tokPos; // '\r\n'


### PR DESCRIPTION
IE < 9 treats '\v' as 'v' instead of a vertical tab ('\x0B').

Read more: http://mathiasbynens.be/notes/javascript-escapes

@mathiasbynens originally found this bug in my Lua parser.
Discussion on luaparse: http://goo.gl/nmoLS
Fix on luaparse: http://goo.gl/v7nxL
Uglify2 also does this: http://goo.gl/xibiK
