### PR TITLE
Allow for scoped inclusion of Acorn inside another library.

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -20,11 +20,11 @@
 // [dammit]: acorn_loose.js
 // [walk]: util/walk.js
 
-(function(mod) {
+(function(root, mod) {
   if (typeof exports == "object" && typeof module == "object") return mod(exports); // CommonJS
   if (typeof define == "function" && define.amd) return define(["exports"], mod); // AMD
-  mod(this.acorn || (this.acorn = {})); // Plain browser env
-})(function(exports) {
+  mod(root.acorn || (root.acorn = {})); // Plain browser env
+})(this, function(exports) {
   "use strict";
 
   exports.version = "0.3.2";

--- a/acorn_loose.js
+++ b/acorn_loose.js
@@ -29,11 +29,11 @@
 // invasive changes and simplifications without creating a complicated
 // tangle.
 
-(function(mod) {
+(function(root, mod) {
   if (typeof exports == "object" && typeof module == "object") return mod(exports, require("./acorn")); // CommonJS
   if (typeof define == "function" && define.amd) return define(["exports", "./acorn"], mod); // AMD
-  mod(this.acorn || (this.acorn = {}), this.acorn); // Plain browser env
-})(function(exports, acorn) {
+  mod(root.acorn || (root.acorn = {}), root.acorn); // Plain browser env
+})(this, function(exports, acorn) {
   "use strict";
 
   var tt = acorn.tokTypes;


### PR DESCRIPTION
Using the same approach as Esprima for declaring the 'acorn' object inside the root scope would allow for inclusion of the library inside a scope other than global, and have it locally exported. This is the approach we would like to use in Paper.js to include Acorn.
