### PR TITLE
Use one-based column numbers.

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -222,7 +222,7 @@
 
   function raise(pos, message) {
     var loc = getLineInfo(input, pos);
-    message += " (" + loc.line + ":" + loc.column + ")";
+    message += " (" + loc.line + ":" + (loc.column + 1) + ")";
     var err = new SyntaxError(message);
     err.pos = pos; err.loc = loc; err.raisedAt = tokPos;
     throw err;


### PR DESCRIPTION
Motivation:

Every programming editor I can find -- except emacs -- uses one-based column numbers. So the question is, do you think the majority of Javascript programmers in this day and age are using emacs or some other editor? If the majority of users are using a one-based editor, then it is much friendlier when you are reading an error report to have one-based column numbers.
