### PR TITLE
Rename var

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -1479,8 +1479,8 @@
         node.operator = tokVal;
         next();
         node.right = parseExprOp(parseMaybeUnary(), prec, noIn);
-        var node = finishNode(node, /&&|\|\|/.test(node.operator) ? "LogicalExpression" : "BinaryExpression");
-        return parseExprOp(node, minPrec, noIn);
+        var exprNode = finishNode(node, /&&|\|\|/.test(node.operator) ? "LogicalExpression" : "BinaryExpression");
+        return parseExprOp(exprNode, minPrec, noIn);
       }
     }
     return left;


### PR DESCRIPTION
Originally node was declared twice, which is a bit confusing. Just renamed it to be a little clearer that it's a separate node from the node var declared above.
