### PR TITLE
Renamed node_t to Node and exported it

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -997,11 +997,13 @@
 
   // Start an AST node, attaching a start offset.
 
-  function node_t() {
+  function Node() {
     this.type = null;
     this.start = tokStart;
     this.end = null;
   }
+  
+  exports.Node = Node;
 
   function node_loc_t() {
     this.start = tokStartLoc;
@@ -1010,7 +1012,7 @@
   }
 
   function startNode() {
-    var node = new node_t();
+    var node = new Node();
     if (options.locations)
       node.loc = new node_loc_t();
     if (options.directSourceFile)
@@ -1025,7 +1027,7 @@
   // only started after its left-hand side has already been parsed.
 
   function startNodeFrom(other) {
-    var node = new node_t();
+    var node = new Node();
     node.start = other.start;
     if (options.locations) {
       node.loc = new node_loc_t();

--- a/acorn_loose.js
+++ b/acorn_loose.js
@@ -193,11 +193,13 @@
     return true;
   }
 
-  function node_t(start) {
+  function Node(start) {
     this.type = null;
     this.start = start;
     this.end = null;
   }
+  
+  exports.Node = Node;
 
   function node_loc_t(start) {
     this.start = start || token.startLoc || {line: 1, column: 0};
@@ -206,7 +208,7 @@
   }
 
   function startNode() {
-    var node = new node_t(token.start);
+    var node = new Node(token.start);
     if (options.locations)
       node.loc = new node_loc_t();
     if (options.directSourceFile)
@@ -215,7 +217,7 @@
   }
 
   function startNodeFrom(other) {
-    var node = new node_t(other.start);
+    var node = new Node(other.start);
     if (options.locations)
       node.loc = new node_loc_t(other.loc.start);
     return node;
@@ -238,7 +240,7 @@
   };
 
   function dummyIdent() {
-    var dummy = new node_t(token.start);
+    var dummy = new Node(token.start);
     dummy.type = "Identifier";
     dummy.end = token.start;
     dummy.name = "✖";


### PR DESCRIPTION
This is to let programmers extend the Node object with utility methods such as `toString()` or `toFunction()`.
