### PR TITLE
[loose parser] Fix interpretation of `f."`

### DIFF
--- a/acorn_loose.js
+++ b/acorn_loose.js
@@ -603,7 +603,7 @@
         if (curLineStart != line && curIndent <= startIndent && tokenStartsLine())
           node.property = dummyIdent();
         else
-          node.property = parsePropertyName() || dummyIdent();
+          node.property = parsePropertyAccessor() || dummyIdent();
         node.computed = false;
         base = finishNode(node, "MemberExpression");
       } else if (token.type == tt.bracketL) {
@@ -729,6 +729,10 @@
 
   function parsePropertyName() {
     if (token.type === tt.num || token.type === tt.string) return parseExprAtom();
+    if (token.type === tt.name || token.type.keyword) return parseIdent();
+  }
+
+  function parsePropertyAccessor() {
     if (token.type === tt.name || token.type.keyword) return parseIdent();
   }
 


### PR DESCRIPTION
Before this the ast produced by parse_dammit crashed in the following code, as
Uglify correctly noticed that `f.""` is invalid.

```
    sample = 'f."';

    loose = require('acorn/acorn_loose');
   uglify = require('uglify-js');

    out = new uglify.OutputStream();
   ast = loose.parse_dammit(sample);
   ast = uglify.AST_Node.from_mozilla_ast(ast);
   ast.print(out);
   // TypeError: Cannot call method 'toString' of undefined
   // member_exp.computed = false && member_exp.property == ""

    console.log(out.toString());
```

After this the round-tripped AST looks like: `t.✖;"";`, which is consistent
with how `foo.{` is parsed.

I also considered making it parse as t[""], but as this only turns up in the
wild when people try to use multiline strings, I felt it was better to be
obviously wrong.
