### PR TITLE
Minor: Remove unused argument from readToken_slash

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -694,7 +694,7 @@
     // of the type given by its first argument.
 
     case 47: // '/'
-      return readToken_slash(code);
+      return readToken_slash();
 
     case 37: case 42: // '%*'
       return readToken_mult_modulo();


### PR DESCRIPTION
Possible dev relic.

readToken_slash currently does not have any arguments and does not appear to look at the arguments object. All existing tests still pass after removal of the extraneous argument while calling readToken_slash.
