### PR TITLE
some linting and refactoring, several loop optimizations

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -110,8 +110,10 @@
 
   function setOptions(opts) {
     options = opts || {};
-    for (var opt in defaultOptions) if (!Object.prototype.hasOwnProperty.call(options, opt))
-      options[opt] = defaultOptions[opt];
+    for (var opt in defaultOptions) {
+      if (!Object.prototype.hasOwnProperty.call(options, opt))
+        options[opt] = defaultOptions[opt];
+    }
     sourceFile = options.sourceFile || null;
   }
 
@@ -125,10 +127,10 @@
     for (var line = 1, cur = 0;;) {
       lineBreak.lastIndex = cur;
       var match = lineBreak.exec(input);
-      if (match && match.index < offset) {
-        ++line;
-        cur = match.index + match[0].length;
-      } else break;
+      var index = match.index;
+      if (!match || index <= offset) break;
+      ++line;
+      cur = index + match[0].length;
     }
     return {line: line, column: offset - cur};
   };
@@ -149,9 +151,16 @@
     function getToken(forceRegexp) {
       lastEnd = tokEnd;
       readToken(forceRegexp);
-      t.start = tokStart; t.end = tokEnd;
-      t.startLoc = tokStartLoc; t.endLoc = tokEndLoc;
-      t.type = tokType; t.value = tokVal;
+      
+      t.start = tokStart;
+      t.end = tokEnd;
+      
+      t.startLoc = tokStartLoc;
+      t.endLoc = tokEndLoc;
+      
+      t.type = tokType;
+      t.value = tokVal;
+      
       return t;
     }
     getToken.jumpTo = function(pos, reAllowed) {
@@ -159,10 +168,10 @@
       if (options.locations) {
         tokCurLine = 1;
         tokLineStart = lineBreak.lastIndex = 0;
-        var match;
-        while ((match = lineBreak.exec(input)) && match.index < pos) {
+        var match, index;
+        while ((match = lineBreak.exec(input)) && (index = match.index) < pos) {
           ++tokCurLine;
-          tokLineStart = match.index + match[0].length;
+          tokLineStart = index + match[0].length;
         }
       }
       tokRegexpAllowed = reAllowed;
@@ -234,7 +243,9 @@
     var loc = getLineInfo(input, pos);
     message += " (" + loc.line + ":" + loc.column + ")";
     var err = new SyntaxError(message);
-    err.pos = pos; err.loc = loc; err.raisedAt = tokPos;
+    err.pos = pos;
+    err.loc = loc;
+    err.raisedAt = tokPos;
     throw err;
   }
 
@@ -254,8 +265,11 @@
   // These are the general types. The `type` property is only used to
   // make them recognizeable when debugging.
 
-  var _num = {type: "num"}, _regexp = {type: "regexp"}, _string = {type: "string"};
-  var _name = {type: "name"}, _eof = {type: "eof"};
+  var _num    = { type: "num" };
+  var _regexp = { type: "regexp" };
+  var _string = { type: "string" };
+  var _name   = { type: "name" };
+  var _eof    = { type: "eof" };
 
   // Keyword tokens. The `keyword` property (also used in keyword-like
   // operators) indicates that the token originated from an
@@ -270,45 +284,87 @@
   // to know when parsing a label, in order to allow or disallow
   // continue jumps to that label.
 
-  var _break = {keyword: "break"}, _case = {keyword: "case", beforeExpr: true}, _catch = {keyword: "catch"};
-  var _continue = {keyword: "continue"}, _debugger = {keyword: "debugger"}, _default = {keyword: "default"};
-  var _do = {keyword: "do", isLoop: true}, _else = {keyword: "else", beforeExpr: true};
-  var _finally = {keyword: "finally"}, _for = {keyword: "for", isLoop: true}, _function = {keyword: "function"};
-  var _if = {keyword: "if"}, _return = {keyword: "return", beforeExpr: true}, _switch = {keyword: "switch"};
-  var _throw = {keyword: "throw", beforeExpr: true}, _try = {keyword: "try"}, _var = {keyword: "var"};
-  var _while = {keyword: "while", isLoop: true}, _with = {keyword: "with"}, _new = {keyword: "new", beforeExpr: true};
-  var _this = {keyword: "this"};
+  var _break    = { keyword: "break"};
+  var _case     = { keyword: "case", beforeExpr: true };
+  var _catch    = { keyword: "catch" };
+  var _continue = { keyword: "continue" };
+  var _debugger = { keyword: "debugger" };
+  var _default  = { keyword: "default" };
+  var _do       = { keyword: "do", isLoop: true };
+  var _else     = { keyword: "else", beforeExpr: true };
+  var _finally  = { keyword: "finally" };
+  var _for      = { keyword: "for", isLoop: true };
+  var _function = { keyword: "function" };
+  var _if       = { keyword: "if" };
+  var _return   = { keyword: "return", beforeExpr: true };
+  var _switch   = { keyword: "switch" };
+  var _throw    = { keyword: "throw", beforeExpr: true };
+  var _try      = { keyword: "try"}, _var = { keyword: "var" };
+  var _while    = { keyword: "while", isLoop: true };
+  var _with     = { keyword: "with" };
+  var _new      = { keyword: "new", beforeExpr: true };
+  var _this     = { keyword: "this" };
 
   // The keywords that denote values.
 
-  var _null = {keyword: "null", atomValue: null}, _true = {keyword: "true", atomValue: true};
-  var _false = {keyword: "false", atomValue: false};
+  var _null  = { keyword: "null", atomValue: null };
+  var _true  = { keyword: "true", atomValue: true };
+  var _false = { keyword: "false", atomValue: false };
 
   // Some keywords are treated as regular operators. `in` sometimes
   // (when parsing `for`) needs to be tested against specifically, so
   // we assign a variable name to it for quick comparing.
 
-  var _in = {keyword: "in", binop: 7, beforeExpr: true};
+  var _in = { keyword: "in", binop: 7, beforeExpr: true };
 
   // Map keyword names to token types.
 
-  var keywordTypes = {"break": _break, "case": _case, "catch": _catch,
-                      "continue": _continue, "debugger": _debugger, "default": _default,
-                      "do": _do, "else": _else, "finally": _finally, "for": _for,
-                      "function": _function, "if": _if, "return": _return, "switch": _switch,
-                      "throw": _throw, "try": _try, "var": _var, "while": _while, "with": _with,
-                      "null": _null, "true": _true, "false": _false, "new": _new, "in": _in,
-                      "instanceof": {keyword: "instanceof", binop: 7, beforeExpr: true}, "this": _this,
-                      "typeof": {keyword: "typeof", prefix: true, beforeExpr: true},
-                      "void": {keyword: "void", prefix: true, beforeExpr: true},
-                      "delete": {keyword: "delete", prefix: true, beforeExpr: true}};
-
+  var keywordTypes = {
+    "break": _break,
+    "case": _case,
+    "catch": _catch,
+    "continue": _continue,
+    "debugger": _debugger,
+    "default": _default,
+    "do": _do,
+    "else": _else,
+    "finally": _finally,
+    "for": _for,
+    "function": _function,
+    "if": _if,
+    "return": _return,
+    "switch": _switch,
+    "throw": _throw,
+    "try": _try,
+    "var": _var,
+    "while": _while,
+    "with": _with,
+    "null": _null,
+    "true": _true,
+    "false": _false,
+    "new": _new,
+    "in": _in,
+    "instanceof": {keyword: "instanceof", binop: 7, beforeExpr: true },
+    "this": _this,
+    "typeof": {keyword: "typeof", prefix: true, beforeExpr: true },
+    "void": {keyword: "void", prefix: true, beforeExpr: true },
+    "delete": {keyword: "delete", prefix: true, beforeExpr: true }
+  };
+  
   // Punctuation token types. Again, the `type` property is purely for debugging.
-
-  var _bracketL = {type: "[", beforeExpr: true}, _bracketR = {type: "]"}, _braceL = {type: "{", beforeExpr: true};
-  var _braceR = {type: "}"}, _parenL = {type: "(", beforeExpr: true}, _parenR = {type: ")"};
-  var _comma = {type: ",", beforeExpr: true}, _semi = {type: ";", beforeExpr: true};
-  var _colon = {type: ":", beforeExpr: true}, _dot = {type: "."}, _ellipsis = {type: "..."}, _question = {type: "?", beforeExpr: true};
+  
+  var _bracketL = { type: "[", beforeExpr: true };
+  var _bracketR = { type: "]" };
+  var _braceL   = { type: "{", beforeExpr: true };
+  var _braceR   = { type: "}" };
+  var _parenL   = { type: "(", beforeExpr: true };
+  var _parenR   = { type: ")" };
+  var _comma    = { type: ",", beforeExpr: true };
+  var _semi     = { type: ";", beforeExpr: true };
+  var _colon    = { type: ":", beforeExpr: true };
+  var _dot      = { type: "." };
+  var _ellipsis = { type: "..." };
+  var _question = { type: "?", beforeExpr: true };
 
   // Operators. These carry several kinds of properties to help the
   // parser use them properly (the presence of these properties is
@@ -326,55 +382,90 @@
   // binary operators with a very low precedence, that should result
   // in AssignmentExpression nodes.
 
-  var _slash = {binop: 10, beforeExpr: true}, _eq = {isAssign: true, beforeExpr: true};
-  var _assign = {isAssign: true, beforeExpr: true};
-  var _incDec = {postfix: true, prefix: true, isUpdate: true}, _prefix = {prefix: true, beforeExpr: true};
-  var _logicalOR = {binop: 1, beforeExpr: true};
-  var _logicalAND = {binop: 2, beforeExpr: true};
-  var _bitwiseOR = {binop: 3, beforeExpr: true};
-  var _bitwiseXOR = {binop: 4, beforeExpr: true};
-  var _bitwiseAND = {binop: 5, beforeExpr: true};
-  var _equality = {binop: 6, beforeExpr: true};
-  var _relational = {binop: 7, beforeExpr: true};
-  var _bitShift = {binop: 8, beforeExpr: true};
-  var _plusMin = {binop: 9, prefix: true, beforeExpr: true};
-  var _multiplyModulo = {binop: 10, beforeExpr: true};
+  var _slash          = { binop: 10, beforeExpr: true };
+  var _eq             = { isAssign: true, beforeExpr: true };
+  var _assign         = { isAssign: true, beforeExpr: true };
+  var _incDec         = { postfix: true, prefix: true, isUpdate: true };
+  var _prefix         = { prefix: true, beforeExpr: true };
+  var _logicalOR      = { binop: 1,  beforeExpr: true };
+  var _logicalAND     = { binop: 2,  beforeExpr: true };
+  var _bitwiseOR      = { binop: 3,  beforeExpr: true };
+  var _bitwiseXOR     = { binop: 4,  beforeExpr: true };
+  var _bitwiseAND     = { binop: 5,  beforeExpr: true };
+  var _equality       = { binop: 6,  beforeExpr: true };
+  var _relational     = { binop: 7,  beforeExpr: true };
+  var _bitShift       = { binop: 8,  beforeExpr: true };
+  var _plusMin        = { binop: 9,  prefix: true, beforeExpr: true };
+  var _multiplyModulo = { binop: 10, beforeExpr: true };
 
   // Provide access to the token types for external users of the
   // tokenizer.
 
-  exports.tokTypes = {bracketL: _bracketL, bracketR: _bracketR, braceL: _braceL, braceR: _braceR,
-                      parenL: _parenL, parenR: _parenR, comma: _comma, semi: _semi, colon: _colon,
-                      dot: _dot, ellipsis: _ellipsis, question: _question, slash: _slash, eq: _eq,
-                      name: _name, eof: _eof, num: _num, regexp: _regexp, string: _string};
-  for (var kw in keywordTypes) exports.tokTypes["_" + kw] = keywordTypes[kw];
-
+  exports.tokTypes = {
+    bracketL: _bracketL,
+    bracketR: _bracketR,
+    braceL:   _braceL,
+    braceR:   _braceR,
+    parenL:   _parenL,
+    parenR:   _parenR,
+    comma:    _comma,
+    semi:     _semi,
+    colon:    _colon,
+    dot:      _dot,
+    ellipsis: _ellipsis,
+    question: _question,
+    slash:    _slash,
+    eq:       _eq,
+    name:     _name,
+    eof:      _eof,
+    num:      _num,
+    regexp:   _regexp,
+    string:   _string
+  };
+  
+  for (var kw in keywordTypes) {
+    exports.tokTypes["_" + kw] = keywordTypes[kw];
+  }
+  
   // This is a trick taken from Esprima. It turns out that, on
   // non-Chrome browsers, to check whether a string is in a set, a
   // predicate containing a big ugly `switch` statement is faster than
   // a regular expression, and on Chrome the two are about on par.
   // This function uses `eval` (non-lexical) to produce such a
   // predicate from a space-separated string of words.
-  //
-  // It starts by sorting the words by length.
-
+  // 
+  // The words are passed as an array
+  
   function makePredicate(words) {
-    words = words.split(" ");
-    var f = "", cats = [];
-    out: for (var i = 0; i < words.length; ++i) {
-      for (var j = 0; j < cats.length; ++j)
-        if (cats[j][0].length == words[i].length) {
-          cats[j].push(words[i]);
-          continue out;
-        }
-      cats.push([words[i]]);
-    }
+    var f = "";
+    var cats = [];
+    
     function compareTo(arr) {
-      if (arr.length == 1) return f += "return str === " + JSON.stringify(arr[0]) + ";";
+      var len = arr.length;
+      if (len === 1)
+        return f += "return str===" + JSON.stringify(arr[0]) + ";";
+      
       f += "switch(str){";
-      for (var i = 0; i < arr.length; ++i) f += "case " + JSON.stringify(arr[i]) + ":";
+      
+      for (var i = len; i >= 0; ) {
+        f += "case " + JSON.stringify(arr[--i]) + ":";
+      }
+      
       f += "return true}return false;";
     }
+    
+    out:
+    for (var i = words.length; i >= 0; ) {
+      var word = words[--i];
+      var len       = fncache.length;
+      for (var j = cats.length; j >= 0; ) {
+        if (cats[--j][0].length === len) {
+          cats[j].push([word]);
+          continue out;
+        }
+      }
+      cats.push(word);
+    
 
     // When there are more than three length categories, an outer
     // switch first dispatches on the lengths, to save on comparisons.
@@ -396,108 +487,186 @@
     }
     return new Function("str", f);
   }
-
+  
   // The ECMAScript 3 reserved word list.
-
-  var isReservedWord3 = makePredicate("abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile");
+  
+  var isReservedWord3 = makePredicate(["abstract",
+                                       "boolean",
+                                       "byte",
+                                       "char",
+                                       "class",
+                                       "double",
+                                       "enum",
+                                       "export",
+                                       "extends",
+                                       "final",
+                                       "float",
+                                       "goto",
+                                       "implements",
+                                       "import",
+                                       "int",
+                                       "interface",
+                                       "long",
+                                       "native",
+                                       "package",
+                                       "private",
+                                       "protected",
+                                       "public",
+                                       "short",
+                                       "static",
+                                       "super",
+                                       "synchronized",
+                                       "throws",
+                                       "transient",
+                                       "volatile"]);
 
   // ECMAScript 5 reserved words.
-
-  var isReservedWord5 = makePredicate("class enum extends super const export import");
+  
+  var isReservedWord5 = makePredicate(["class",
+                                       "enum",
+                                       "extends",
+                                       "super",
+                                       "const",
+                                       "export",
+                                       "import"]);
 
   // The additional reserved words in strict mode.
-
-  var isStrictReservedWord = makePredicate("implements interface let package private protected public static yield");
+  
+  var isStrictReservedWord = makePredicate(["implements",
+                                            "interface",
+                                            "let",
+                                            "package",
+                                            "private",
+                                            "protected",
+                                            "public",
+                                            "static",
+                                            "yield"]);
 
   // The forbidden variable names in strict mode.
-
-  var isStrictBadIdWord = makePredicate("eval arguments");
-
+  
+  var isStrictBadIdWord = makePredicate(["eval",
+                                         "arguments"]);
+  
   // And the keywords.
-
-  var isKeyword = makePredicate("break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this");
-
+  
+  var isKeyword = makePredicate(["break",
+                                 "case",
+                                 "catch",
+                                 "continue",
+                                 "debugger",
+                                 "default",
+                                 "do",
+                                 "else",
+                                 "finally",
+                                 "for",
+                                 "function",
+                                 "if",
+                                 "return",
+                                 "switch",
+                                 "throw",
+                                 "try",
+                                 "var",
+                                 "while",
+                                 "with",
+                                 "null",
+                                 "true",
+                                 "false",
+                                 "instanceof",
+                                 "typeof",
+                                 "void",
+                                 "delete",
+                                 "new",
+                                 "in",
+                                 "this"]);
+  
   // ## Character categories
-
+  
   // Big ugly regular expressions that match characters in the
   // whitespace, identifier, and identifier-start categories. These
   // are only applied when a character is found to actually have a
   // code point above 128.
-
+  
   var nonASCIIwhitespace = /[\u1680\u180e\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
   var nonASCIIidentifierStartChars = "\xaa\xb5\xba\xc0-\xd6\xd8-\xf6\xf8-\u02c1\u02c6-\u02d1\u02e0-\u02e4\u02ec\u02ee\u0370-\u0374\u0376\u0377\u037a-\u037d\u0386\u0388-\u038a\u038c\u038e-\u03a1\u03a3-\u03f5\u03f7-\u0481\u048a-\u0527\u0531-\u0556\u0559\u0561-\u0587\u05d0-\u05ea\u05f0-\u05f2\u0620-\u064a\u066e\u066f\u0671-\u06d3\u06d5\u06e5\u06e6\u06ee\u06ef\u06fa-\u06fc\u06ff\u0710\u0712-\u072f\u074d-\u07a5\u07b1\u07ca-\u07ea\u07f4\u07f5\u07fa\u0800-\u0815\u081a\u0824\u0828\u0840-\u0858\u08a0\u08a2-\u08ac\u0904-\u0939\u093d\u0950\u0958-\u0961\u0971-\u0977\u0979-\u097f\u0985-\u098c\u098f\u0990\u0993-\u09a8\u09aa-\u09b0\u09b2\u09b6-\u09b9\u09bd\u09ce\u09dc\u09dd\u09df-\u09e1\u09f0\u09f1\u0a05-\u0a0a\u0a0f\u0a10\u0a13-\u0a28\u0a2a-\u0a30\u0a32\u0a33\u0a35\u0a36\u0a38\u0a39\u0a59-\u0a5c\u0a5e\u0a72-\u0a74\u0a85-\u0a8d\u0a8f-\u0a91\u0a93-\u0aa8\u0aaa-\u0ab0\u0ab2\u0ab3\u0ab5-\u0ab9\u0abd\u0ad0\u0ae0\u0ae1\u0b05-\u0b0c\u0b0f\u0b10\u0b13-\u0b28\u0b2a-\u0b30\u0b32\u0b33\u0b35-\u0b39\u0b3d\u0b5c\u0b5d\u0b5f-\u0b61\u0b71\u0b83\u0b85-\u0b8a\u0b8e-\u0b90\u0b92-\u0b95\u0b99\u0b9a\u0b9c\u0b9e\u0b9f\u0ba3\u0ba4\u0ba8-\u0baa\u0bae-\u0bb9\u0bd0\u0c05-\u0c0c\u0c0e-\u0c10\u0c12-\u0c28\u0c2a-\u0c33\u0c35-\u0c39\u0c3d\u0c58\u0c59\u0c60\u0c61\u0c85-\u0c8c\u0c8e-\u0c90\u0c92-\u0ca8\u0caa-\u0cb3\u0cb5-\u0cb9\u0cbd\u0cde\u0ce0\u0ce1\u0cf1\u0cf2\u0d05-\u0d0c\u0d0e-\u0d10\u0d12-\u0d3a\u0d3d\u0d4e\u0d60\u0d61\u0d7a-\u0d7f\u0d85-\u0d96\u0d9a-\u0db1\u0db3-\u0dbb\u0dbd\u0dc0-\u0dc6\u0e01-\u0e30\u0e32\u0e33\u0e40-\u0e46\u0e81\u0e82\u0e84\u0e87\u0e88\u0e8a\u0e8d\u0e94-\u0e97\u0e99-\u0e9f\u0ea1-\u0ea3\u0ea5\u0ea7\u0eaa\u0eab\u0ead-\u0eb0\u0eb2\u0eb3\u0ebd\u0ec0-\u0ec4\u0ec6\u0edc-\u0edf\u0f00\u0f40-\u0f47\u0f49-\u0f6c\u0f88-\u0f8c\u1000-\u102a\u103f\u1050-\u1055\u105a-\u105d\u1061\u1065\u1066\u106e-\u1070\u1075-\u1081\u108e\u10a0-\u10c5\u10c7\u10cd\u10d0-\u10fa\u10fc-\u1248\u124a-\u124d\u1250-\u1256\u1258\u125a-\u125d\u1260-\u1288\u128a-\u128d\u1290-\u12b0\u12b2-\u12b5\u12b8-\u12be\u12c0\u12c2-\u12c5\u12c8-\u12d6\u12d8-\u1310\u1312-\u1315\u1318-\u135a\u1380-\u138f\u13a0-\u13f4\u1401-\u166c\u166f-\u167f\u1681-\u169a\u16a0-\u16ea\u16ee-\u16f0\u1700-\u170c\u170e-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176c\u176e-\u1770\u1780-\u17b3\u17d7\u17dc\u1820-\u1877\u1880-\u18a8\u18aa\u18b0-\u18f5\u1900-\u191c\u1950-\u196d\u1970-\u1974\u1980-\u19ab\u19c1-\u19c7\u1a00-\u1a16\u1a20-\u1a54\u1aa7\u1b05-\u1b33\u1b45-\u1b4b\u1b83-\u1ba0\u1bae\u1baf\u1bba-\u1be5\u1c00-\u1c23\u1c4d-\u1c4f\u1c5a-\u1c7d\u1ce9-\u1cec\u1cee-\u1cf1\u1cf5\u1cf6\u1d00-\u1dbf\u1e00-\u1f15\u1f18-\u1f1d\u1f20-\u1f45\u1f48-\u1f4d\u1f50-\u1f57\u1f59\u1f5b\u1f5d\u1f5f-\u1f7d\u1f80-\u1fb4\u1fb6-\u1fbc\u1fbe\u1fc2-\u1fc4\u1fc6-\u1fcc\u1fd0-\u1fd3\u1fd6-\u1fdb\u1fe0-\u1fec\u1ff2-\u1ff4\u1ff6-\u1ffc\u2071\u207f\u2090-\u209c\u2102\u2107\u210a-\u2113\u2115\u2119-\u211d\u2124\u2126\u2128\u212a-\u212d\u212f-\u2139\u213c-\u213f\u2145-\u2149\u214e\u2160-\u2188\u2c00-\u2c2e\u2c30-\u2c5e\u2c60-\u2ce4\u2ceb-\u2cee\u2cf2\u2cf3\u2d00-\u2d25\u2d27\u2d2d\u2d30-\u2d67\u2d6f\u2d80-\u2d96\u2da0-\u2da6\u2da8-\u2dae\u2db0-\u2db6\u2db8-\u2dbe\u2dc0-\u2dc6\u2dc8-\u2dce\u2dd0-\u2dd6\u2dd8-\u2dde\u2e2f\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303c\u3041-\u3096\u309d-\u309f\u30a1-\u30fa\u30fc-\u30ff\u3105-\u312d\u3131-\u318e\u31a0-\u31ba\u31f0-\u31ff\u3400-\u4db5\u4e00-\u9fcc\ua000-\ua48c\ua4d0-\ua4fd\ua500-\ua60c\ua610-\ua61f\ua62a\ua62b\ua640-\ua66e\ua67f-\ua697\ua6a0-\ua6ef\ua717-\ua71f\ua722-\ua788\ua78b-\ua78e\ua790-\ua793\ua7a0-\ua7aa\ua7f8-\ua801\ua803-\ua805\ua807-\ua80a\ua80c-\ua822\ua840-\ua873\ua882-\ua8b3\ua8f2-\ua8f7\ua8fb\ua90a-\ua925\ua930-\ua946\ua960-\ua97c\ua984-\ua9b2\ua9cf\uaa00-\uaa28\uaa40-\uaa42\uaa44-\uaa4b\uaa60-\uaa76\uaa7a\uaa80-\uaaaf\uaab1\uaab5\uaab6\uaab9-\uaabd\uaac0\uaac2\uaadb-\uaadd\uaae0-\uaaea\uaaf2-\uaaf4\uab01-\uab06\uab09-\uab0e\uab11-\uab16\uab20-\uab26\uab28-\uab2e\uabc0-\uabe2\uac00-\ud7a3\ud7b0-\ud7c6\ud7cb-\ud7fb\uf900-\ufa6d\ufa70-\ufad9\ufb00-\ufb06\ufb13-\ufb17\ufb1d\ufb1f-\ufb28\ufb2a-\ufb36\ufb38-\ufb3c\ufb3e\ufb40\ufb41\ufb43\ufb44\ufb46-\ufbb1\ufbd3-\ufd3d\ufd50-\ufd8f\ufd92-\ufdc7\ufdf0-\ufdfb\ufe70-\ufe74\ufe76-\ufefc\uff21-\uff3a\uff41-\uff5a\uff66-\uffbe\uffc2-\uffc7\uffca-\uffcf\uffd2-\uffd7\uffda-\uffdc";
   var nonASCIIidentifierChars = "\u0300-\u036f\u0483-\u0487\u0591-\u05bd\u05bf\u05c1\u05c2\u05c4\u05c5\u05c7\u0610-\u061a\u0620-\u0649\u0672-\u06d3\u06e7-\u06e8\u06fb-\u06fc\u0730-\u074a\u0800-\u0814\u081b-\u0823\u0825-\u0827\u0829-\u082d\u0840-\u0857\u08e4-\u08fe\u0900-\u0903\u093a-\u093c\u093e-\u094f\u0951-\u0957\u0962-\u0963\u0966-\u096f\u0981-\u0983\u09bc\u09be-\u09c4\u09c7\u09c8\u09d7\u09df-\u09e0\u0a01-\u0a03\u0a3c\u0a3e-\u0a42\u0a47\u0a48\u0a4b-\u0a4d\u0a51\u0a66-\u0a71\u0a75\u0a81-\u0a83\u0abc\u0abe-\u0ac5\u0ac7-\u0ac9\u0acb-\u0acd\u0ae2-\u0ae3\u0ae6-\u0aef\u0b01-\u0b03\u0b3c\u0b3e-\u0b44\u0b47\u0b48\u0b4b-\u0b4d\u0b56\u0b57\u0b5f-\u0b60\u0b66-\u0b6f\u0b82\u0bbe-\u0bc2\u0bc6-\u0bc8\u0bca-\u0bcd\u0bd7\u0be6-\u0bef\u0c01-\u0c03\u0c46-\u0c48\u0c4a-\u0c4d\u0c55\u0c56\u0c62-\u0c63\u0c66-\u0c6f\u0c82\u0c83\u0cbc\u0cbe-\u0cc4\u0cc6-\u0cc8\u0cca-\u0ccd\u0cd5\u0cd6\u0ce2-\u0ce3\u0ce6-\u0cef\u0d02\u0d03\u0d46-\u0d48\u0d57\u0d62-\u0d63\u0d66-\u0d6f\u0d82\u0d83\u0dca\u0dcf-\u0dd4\u0dd6\u0dd8-\u0ddf\u0df2\u0df3\u0e34-\u0e3a\u0e40-\u0e45\u0e50-\u0e59\u0eb4-\u0eb9\u0ec8-\u0ecd\u0ed0-\u0ed9\u0f18\u0f19\u0f20-\u0f29\u0f35\u0f37\u0f39\u0f41-\u0f47\u0f71-\u0f84\u0f86-\u0f87\u0f8d-\u0f97\u0f99-\u0fbc\u0fc6\u1000-\u1029\u1040-\u1049\u1067-\u106d\u1071-\u1074\u1082-\u108d\u108f-\u109d\u135d-\u135f\u170e-\u1710\u1720-\u1730\u1740-\u1750\u1772\u1773\u1780-\u17b2\u17dd\u17e0-\u17e9\u180b-\u180d\u1810-\u1819\u1920-\u192b\u1930-\u193b\u1951-\u196d\u19b0-\u19c0\u19c8-\u19c9\u19d0-\u19d9\u1a00-\u1a15\u1a20-\u1a53\u1a60-\u1a7c\u1a7f-\u1a89\u1a90-\u1a99\u1b46-\u1b4b\u1b50-\u1b59\u1b6b-\u1b73\u1bb0-\u1bb9\u1be6-\u1bf3\u1c00-\u1c22\u1c40-\u1c49\u1c5b-\u1c7d\u1cd0-\u1cd2\u1d00-\u1dbe\u1e01-\u1f15\u200c\u200d\u203f\u2040\u2054\u20d0-\u20dc\u20e1\u20e5-\u20f0\u2d81-\u2d96\u2de0-\u2dff\u3021-\u3028\u3099\u309a\ua640-\ua66d\ua674-\ua67d\ua69f\ua6f0-\ua6f1\ua7f8-\ua800\ua806\ua80b\ua823-\ua827\ua880-\ua881\ua8b4-\ua8c4\ua8d0-\ua8d9\ua8f3-\ua8f7\ua900-\ua909\ua926-\ua92d\ua930-\ua945\ua980-\ua983\ua9b3-\ua9c0\uaa00-\uaa27\uaa40-\uaa41\uaa4c-\uaa4d\uaa50-\uaa59\uaa7b\uaae0-\uaae9\uaaf2-\uaaf3\uabc0-\uabe1\uabec\uabed\uabf0-\uabf9\ufb20-\ufb28\ufe00-\ufe0f\ufe20-\ufe26\ufe33\ufe34\ufe4d-\ufe4f\uff10-\uff19\uff3f";
   var nonASCIIidentifierStart = new RegExp("[" + nonASCIIidentifierStartChars + "]");
   var nonASCIIidentifier = new RegExp("[" + nonASCIIidentifierStartChars + nonASCIIidentifierChars + "]");
-
+  
   // Whether a single character denotes a newline.
-
+  
   var newline = /[\n\r\u2028\u2029]/;
-
+  
   // Matches a whole line break (where CRLF is considered a single
   // line break). Used to count lines.
-
+  
   var lineBreak = /\r\n|[\n\r\u2028\u2029]/g;
-
+  
   // Test whether a given character code starts an identifier.
-
+  
   var isIdentifierStart = exports.isIdentifierStart = function(code) {
-    if (code < 65) return code === 36;
-    if (code < 91) return true;
-    if (code < 97) return code === 95;
-    if (code < 123)return true;
-    return code >= 0xaa && nonASCIIidentifierStart.test(String.fromCharCode(code));
+    return (code === 36 ||
+            64 <= code < 91 ||
+            code === 95 ||
+            96 < code < 123 ||
+            (code >= 0xaa && nonASCIIidentifierStart.test(String.fromCharCode(code))));
   };
-
+  
   // Test whether a given character is part of an identifier.
-
+  
   var isIdentifierChar = exports.isIdentifierChar = function(code) {
-    if (code < 48) return code === 36;
-    if (code < 58) return true;
-    if (code < 65) return false;
-    if (code < 91) return true;
-    if (code < 97) return code === 95;
-    if (code < 123)return true;
-    return code >= 0xaa && nonASCIIidentifier.test(String.fromCharCode(code));
+    return (code === 36 ||
+            47 < code < 58 ||
+            64 < code < 91 ||
+            code === 95 ||
+            96 < code < 123 ||
+            (code >= 0xaa && nonASCIIidentifier.test(String.fromCharCode(code))));
   };
-
+  
   // ## Tokenizer
-
+  
   // These are used when `options.locations` is on, for the
   // `tokStartLoc` and `tokEndLoc` properties.
-
+  
   function Position() {
     this.line = tokCurLine;
     this.column = tokPos - tokLineStart;
   }
-
+  
   // Reset the token state. Used at the start of a parse.
-
+  
   function initTokenState() {
     tokCurLine = 1;
     tokPos = tokLineStart = 0;
     tokRegexpAllowed = true;
     skipSpace();
   }
-
+  
   // Called at the end of every token. Sets `tokEnd`, `tokVal`, and
   // `tokRegexpAllowed`, and skips the space after the token, so that
   // the next one's `tokStart` will point at the right position.
-
+  
   function finishToken(type, val) {
     tokEnd = tokPos;
-    if (options.locations) tokEndLoc = new Position;
+    
+    if (options.locations)
+      tokEndLoc = new Position;
+    
     tokType = type;
     skipSpace();
+    
     tokVal = val;
     tokRegexpAllowed = type.beforeExpr;
   }
-
+  
   function skipBlockComment() {
-    var startLoc = options.onComment && options.locations && new Position;
+    var startLoc = (options.onComment && options.locations && new Position);
     var start = tokPos, end = input.indexOf("*/", tokPos += 2);
-    if (end === -1) raise(tokPos - 2, "Unterminated comment");
+    
+    if (end === -1)
+      raise(tokPos - 2, "Unterminated comment");
+    
     tokPos = end + 2;
+    
     if (options.locations) {
       lineBreak.lastIndex = start;
       var match;
@@ -506,69 +675,103 @@
         tokLineStart = match.index + match[0].length;
       }
     }
-    if (options.onComment)
-      options.onComment(true, input.slice(start + 2, end), start, tokPos,
-                        startLoc, options.locations && new Position);
+    
+    if (options.onComment) {
+      options.onComment(true,
+                        input.slice(start + 2, end),
+                        start,
+                        tokPos,
+                        startLoc,
+                        options.locations && new Position);
+    }
   }
-
+  
   function skipLineComment() {
     var start = tokPos;
-    var startLoc = options.onComment && options.locations && new Position;
-    var ch = input.charCodeAt(tokPos+=2);
-    while (tokPos < inputLen && ch !== 10 && ch !== 13 && ch !== 8232 && ch !== 8233) {
-      ++tokPos;
+    var startLoc = (options.onComment && options.locations && new Position);
+    var ch = input.charCodeAt(tokPos += 2);
+    while_loop:
+    while (tokPos < inputLen) {
+      switch (ch) {
+        case 10:
+        case 13:
+        case 8232:
+        case 8233:
+          break while_loop;
+        default:
+          ++tokPos;
+      }
       ch = input.charCodeAt(tokPos);
     }
-    if (options.onComment)
-      options.onComment(false, input.slice(start + 2, tokPos), start, tokPos,
-                        startLoc, options.locations && new Position);
+    if (options.onComment) {
+      options.onComment(false,
+                        input.slice(start + 2, tokPos),
+                        start,
+                        tokPos,
+                        startLoc,
+                        options.locations && new Position);
+    }
   }
-
+  
   // Called at the start of the parse and after every token. Skips
   // whitespace and comments, and.
-
+  
   function skipSpace() {
+    while_loop:
     while (tokPos < inputLen) {
       var ch = input.charCodeAt(tokPos);
-      if (ch === 32) { // ' '
-        ++tokPos;
-      } else if (ch === 13) {
-        ++tokPos;
-        var next = input.charCodeAt(tokPos);
-        if (next === 10) {
+      switch (ch) {
+        case 32:
           ++tokPos;
-        }
-        if (options.locations) {
-          ++tokCurLine;
-          tokLineStart = tokPos;
-        }
-      } else if (ch === 10 || ch === 8232 || ch === 8233) {
-        ++tokPos;
-        if (options.locations) {
-          ++tokCurLine;
-          tokLineStart = tokPos;
-        }
-      } else if (ch > 8 && ch < 14) {
-        ++tokPos;
-      } else if (ch === 47) { // '/'
-        var next = input.charCodeAt(tokPos + 1);
-        if (next === 42) { // '*'
-          skipBlockComment();
-        } else if (next === 47) { // '/'
-          skipLineComment();
-        } else break;
-      } else if (ch === 160) { // '\xa0'
-        ++tokPos;
-      } else if (ch >= 5760 && nonASCIIwhitespace.test(String.fromCharCode(ch))) {
-        ++tokPos;
-      } else {
-        break;
+          continue while_loop;
+        case 13:
+          var next = input.charCodeAt(tokPos);
+          if (next === 10) {
+            ++tokPos;
+          }
+          if (options.locations) {
+            ++tokCurLine;
+            tokLineStart = tokPos;
+          }
+          continue while_loop;
+        case 10:
+        case 8232:
+        case 8233:
+          if (options.locations) {
+            ++tokCurLine;
+            tokLineStart = tokPos;
+          }
+          continue while_loop;
+        case 47:
+          var next = input.charCodeAt(tokPos + 1);
+          if (next === 42) { // '*'
+            skipBlockComment();
+          } else if (next === 47) { // '/'
+            skipLineComment();
+          } else {
+            break while_loop;
+          }
+          continue while_loop;
+        case 14:
+        case 13:
+        case 12:
+        case 11:
+        case 10:
+        case 9:
+        case 8:
+        case 160:
+          ++tokPos;
+          continue while_loop;
+        default:
+          if (ch < 5760 || !nonASCIIwhitespace.test(String.fromCharCode(ch)))
+            break while_loop;
+          ++tokPos;
       }
     }
   }
-
+  
   // ### Token reading
-
+  
   // This is the function that is called to fetch the next token. It
   // is somewhat obscure, because it works in character codes rather
   // than characters, and because operator parsing has been inlined
@@ -578,11 +781,15 @@
   //
   // The `forceRegexp` parameter is used in the one case where the
   // `tokRegexpAllowed` trick does not work. See `parseStatement`.
-
+  
   function readToken_dot() {
     var next = input.charCodeAt(tokPos + 1);
-    if (next >= 48 && next <= 57) return readNumber(true);
+    
+    if (next >= 48 && next <= 57)
+      return readNumber(true);
+    
     var next2 = input.charCodeAt(tokPos + 2);
+    
     if (options.ecmaVersion >= 6 && next === 46 && next2 === 46) { // 46 = dot '.'
       tokPos += 3;
       return finishToken(_ellipsis);
@@ -591,37 +798,57 @@
       return finishToken(_dot);
     }
   }
-
+  
   function readToken_slash() { // '/'
     var next = input.charCodeAt(tokPos + 1);
-    if (tokRegexpAllowed) {++tokPos; return readRegexp();}
-    if (next === 61) return finishOp(_assign, 2);
+    
+    if (tokRegexpAllowed) {
+      ++tokPos;
+      return readRegexp();
+    }
+    
+    if (next === 61)
+      return finishOp(_assign, 2);
+    
     return finishOp(_slash, 1);
   }
-
+  
   function readToken_mult_modulo() { // '%*'
     var next = input.charCodeAt(tokPos + 1);
-    if (next === 61) return finishOp(_assign, 2);
+    
+    if (next === 61)
+      return finishOp(_assign, 2);
+    
     return finishOp(_multiplyModulo, 1);
   }
-
+  
   function readToken_pipe_amp(code) { // '|&'
     var next = input.charCodeAt(tokPos + 1);
-    if (next === code) return finishOp(code === 124 ? _logicalOR : _logicalAND, 2);
-    if (next === 61) return finishOp(_assign, 2);
+    
+    if (next === code)
+      return finishOp(code === 124 ? _logicalOR : _logicalAND, 2);
+      
+    if (next === 61)
+      return finishOp(_assign, 2);
+    
     return finishOp(code === 124 ? _bitwiseOR : _bitwiseAND, 1);
   }
-
+  
   function readToken_caret() { // '^'
     var next = input.charCodeAt(tokPos + 1);
-    if (next === 61) return finishOp(_assign, 2);
+    
+    if (next === 61)
+      return finishOp(_assign, 2);
+    
     return finishOp(_bitwiseXOR, 1);
   }
 
   function readToken_plus_min(code) { // '+-'
     var next = input.charCodeAt(tokPos + 1);
+    
     if (next === code) {
-      if (next == 45 && input.charCodeAt(tokPos + 2) == 62 &&
+      if (next == 45 &&
+          input.charCodeAt(tokPos + 2) == 62 &&
           newline.test(input.slice(lastEnd, tokPos))) {
         // A `-->` line comment
         tokPos += 3;
@@ -631,7 +858,10 @@
       }
       return finishOp(_incDec, 2);
     }
-    if (next === 61) return finishOp(_assign, 2);
+    
+    if (next === 61)
+      return finishOp(_assign, 2);
+    
     return finishOp(_plusMin, 1);
   }
 
@@ -639,29 +869,40 @@
     var next = input.charCodeAt(tokPos + 1);
     var size = 1;
     if (next === code) {
-      size = code === 62 && input.charCodeAt(tokPos + 2) === 62 ? 3 : 2;
-      if (input.charCodeAt(tokPos + size) === 61) return finishOp(_assign, size + 1);
+      size = (code === 62 && input.charCodeAt(tokPos + 2) === 62) ? 3 : 2;
+      
+      if (input.charCodeAt(tokPos + size) === 61)
+        return finishOp(_assign, size + 1);
+      
       return finishOp(_bitShift, size);
     }
-    if (next == 33 && code == 60 && input.charCodeAt(tokPos + 2) == 45 &&
-        input.charCodeAt(tokPos + 3) == 45) {
+    
+    if (next === 33 &&
+        code === 60 &&
+        input.charCodeAt(tokPos + 2) === 45 &&
+        input.charCodeAt(tokPos + 3) === 45) {
       // `<!--`, an XML-style comment that should be interpreted as a line comment
       tokPos += 4;
       skipLineComment();
       skipSpace();
       return readToken();
     }
+    
     if (next === 61)
-      size = input.charCodeAt(tokPos + 2) === 61 ? 3 : 2;
+      size = (input.charCodeAt(tokPos + 2) === 61) ? 3 : 2;
+    
     return finishOp(_relational, size);
   }
 
   function readToken_eq_excl(code) { // '=!'
     var next = input.charCodeAt(tokPos + 1);
-    if (next === 61) return finishOp(_equality, input.charCodeAt(tokPos + 2) === 61 ? 3 : 2);
+    
+    if (next === 61)
+      return finishOp(_equality, (input.charCodeAt(tokPos + 2) === 61) ? 3 : 2);
+    
     return finishOp(code === 61 ? _eq : _prefix, 1);
   }
-
+  
   function getTokenFromCode(code) {
     switch(code) {
       // The interpretation of a dot depends on whether it is followed
@@ -687,11 +928,20 @@
       if (next === 120 || next === 88) return readHexNumber();
       // Anything else beginning with a digit is an integer, octal
       // number, or float.
-    case 49: case 50: case 51: case 52: case 53: case 54: case 55: case 56: case 57: // 1-9
+    case 49: // 1-9
+    case 50:
+    case 51:
+    case 52:
+    case 53:
+    case 54:
+    case 55:
+    case 56:
+    case 57:
       return readNumber(false);
 
       // Quotes produce strings.
-    case 34: case 39: // '"', "'"
+    case 34: // '"', "'"
+    case 39:
       return readString(code);
 
     // Operators are parsed inline in tiny state machines. '=' (61) is
@@ -702,22 +952,27 @@
     case 47: // '/'
       return readToken_slash(code);
 
-    case 37: case 42: // '%*'
+    case 37: // '%*'
+    case 42:
       return readToken_mult_modulo();
 
-    case 124: case 38: // '|&'
+    case 124: // '|&'
+    case 38:
       return readToken_pipe_amp(code);
 
     case 94: // '^'
       return readToken_caret();
 
-    case 43: case 45: // '+-'
+    case 43: // '+-'
+    case 45:
       return readToken_plus_min(code);
 
-    case 60: case 62: // '<>'
+    case 60: // '<>'
+    case 62:
       return readToken_lt_gt(code);
 
-    case 61: case 33: // '=!'
+    case 61: // '=!'
+    case 33:
       return readToken_eq_excl(code);
 
     case 126: // '~'
@@ -726,18 +981,25 @@
 
     return false;
   }
-
+  
   function readToken(forceRegexp) {
-    if (!forceRegexp) tokStart = tokPos;
-    else tokPos = tokStart + 1;
-    if (options.locations) tokStartLoc = new Position;
-    if (forceRegexp) return readRegexp();
-    if (tokPos >= inputLen) return finishToken(_eof);
+    if (!forceRegexp) {
+      tokStart = tokPos;
+    } else {
+      tokPos = tokStart + 1;
+    }
+    if (options.locations)
+      tokStartLoc = new Position;
+    if (forceRegexp)
+      return readRegexp();
+    if (tokPos >= inputLen)
+      return finishToken(_eof);
 
     var code = input.charCodeAt(tokPos);
     // Identifier or keyword. '\uXXXX' sequences are allowed in
     // identifiers, so '\' also dispatches to that.
-    if (isIdentifierStart(code) || code === 92 /* '\' */) return readWord();
+    if (isIdentifierStart(code) || code === 92 /* '\' */)
+      return readWord();
 
     var tok = getTokenFromCode(code);
 
@@ -745,33 +1007,53 @@
       // If we are here, we either found a non-ASCII identifier
       // character, or something that's entirely disallowed.
       var ch = String.fromCharCode(code);
-      if (ch === "\\" || nonASCIIidentifierStart.test(ch)) return readWord();
+      if (ch === "\\" || nonASCIIidentifierStart.test(ch))
+        return readWord();
+      
       raise(tokPos, "Unexpected character '" + ch + "'");
     }
     return tok;
   }
-
+  
   function finishOp(type, size) {
     var str = input.slice(tokPos, tokPos + size);
     tokPos += size;
     finishToken(type, str);
   }
-
+  
   // Parse a regular expression. Some context-awareness is necessary,
   // since a '/' inside a '[]' set does not end the expression.
-
+  
   function readRegexp() {
     var content = "", escaped, inClass, start = tokPos;
+    for_loop:
     for (;;) {
-      if (tokPos >= inputLen) raise(start, "Unterminated regular expression");
+      if (tokPos >= inputLen)
+        raise(start, "Unterminated regular expression");
+      
       var ch = input.charAt(tokPos);
-      if (newline.test(ch)) raise(start, "Unterminated regular expression");
+      
+      if (newline.test(ch))
+        raise(start, "Unterminated regular expression");
+      
       if (!escaped) {
-        if (ch === "[") inClass = true;
-        else if (ch === "]" && inClass) inClass = false;
-        else if (ch === "/" && !inClass) break;
-        escaped = ch === "\\";
-      } else escaped = false;
+        switch (ch) {
+          case "\\":
+            escaped = true;
+            ++tokPos;
+            continue for_loop;
+          case "[":
+            inClass = true;
+            break;
+          case "]":
+            inClass = false; // if already out of a class, this changes nothing
+            break;
+          case "/":
+            break for_loop;
+        }
+      } else {
+        escaped = false;
+      }
       ++tokPos;
     }
     var content = input.slice(start, tokPos);
@@ -779,69 +1061,107 @@
     // Need to use `readWord1` because '\uXXXX' sequences are allowed
     // here (don't ask).
     var mods = readWord1();
-    if (mods && !/^[gmsiy]*$/.test(mods)) raise(start, "Invalid regular expression flag");
+    if (mods && !/^[gmsiy]*$/.test(mods))
+      raise(start, "Invalid regular expression flag");
+    
     try {
       var value = new RegExp(content, mods);
     } catch (e) {
-      if (e instanceof SyntaxError) raise(start, "Error parsing regular expression: " + e.message);
+      if (e instanceof SyntaxError)
+        raise(start, "Error parsing regular expression: " + e.message);
+      
       raise(e);
     }
     return finishToken(_regexp, value);
   }
-
+  
+  function readIntHelper(num) {
+    switch (true) {
+      case num < 48: return Infinity;
+      case num < 58: return num - 48;
+      case num < 65: return Infinity;
+      case num < 97: return num - 97 + 10;
+      default: return Infinity;
+    }
+  }
+  
   // Read an integer in the given radix. Return null if zero digits
   // were read, the integer value otherwise. When `len` is given, this
   // will return `null` unless the integer has exactly `len` digits.
-
+  
   function readInt(radix, len) {
-    var start = tokPos, total = 0;
-    for (var i = 0, e = len == null ? Infinity : len; i < e; ++i) {
-      var code = input.charCodeAt(tokPos), val;
-      if (code >= 97) val = code - 97 + 10; // a
-      else if (code >= 65) val = code - 65 + 10; // A
-      else if (code >= 48 && code <= 57) val = code - 48; // 0-9
-      else val = Infinity;
+    var start = tokPos;
+    var total = 0;
+    for (var i = (isNull(len)) ? Infinity : len; i >= 0; --i) {
+      var val = readIntHelper(input.charCodeAt(tokPos))
       if (val >= radix) break;
       ++tokPos;
       total = total * radix + val;
     }
-    if (tokPos === start || len != null && tokPos - start !== len) return null;
+    
+    if (tokPos === start || (!isNull(len) && tokPos - start !== len))
+      return null;
 
     return total;
   }
 
   function readHexNumber() {
     tokPos += 2; // 0x
+    
     var val = readInt(16);
-    if (val == null) raise(tokStart + 2, "Expected hexadecimal number");
-    if (isIdentifierStart(input.charCodeAt(tokPos))) raise(tokPos, "Identifier directly after number");
+    
+    if (val == null)
+      raise(tokStart + 2, "Expected hexadecimal number");
+    
+    if (isIdentifierStart(input.charCodeAt(tokPos)))
+      raise(tokPos, "Identifier directly after number");
+    
     return finishToken(_num, val);
   }
 
   // Read an integer, octal integer, or floating-point number.
 
   function readNumber(startsWithDot) {
-    var start = tokPos, isFloat = false, octal = input.charCodeAt(tokPos) === 48;
-    if (!startsWithDot && readInt(10) === null) raise(start, "Invalid number");
+    var start = tokPos;
+    var isFloat = false;
+    var octal = (input.charCodeAt(tokPos) === 48);
+    
+    if (!startsWithDot && readInt(10) === null)
+      raise(start, "Invalid number");
+    
     if (input.charCodeAt(tokPos) === 46) {
       ++tokPos;
       readInt(10);
       isFloat = true;
     }
+    
     var next = input.charCodeAt(tokPos);
+    
     if (next === 69 || next === 101) { // 'eE'
       next = input.charCodeAt(++tokPos);
-      if (next === 43 || next === 45) ++tokPos; // '+-'
-      if (readInt(10) === null) raise(start, "Invalid number");
+      
+      if (next === 43 || next === 45) // '+-'
+        ++tokPos;
+      
+      if (isNull(readInt(10) === null))
+        raise(start, "Invalid number");
+      
       isFloat = true;
     }
-    if (isIdentifierStart(input.charCodeAt(tokPos))) raise(tokPos, "Identifier directly after number");
+    
+    if (isIdentifierStart(input.charCodeAt(tokPos)))
+      raise(tokPos, "Identifier directly after number");
 
     var str = input.slice(start, tokPos), val;
-    if (isFloat) val = parseFloat(str);
-    else if (!octal || str.length === 1) val = parseInt(str, 10);
-    else if (/[89]/.test(str) || strict) raise(start, "Invalid number");
-    else val = parseInt(str, 8);
+    if (isFloat) {
+      val = parseFloat(str);
+    } else if (!octal || str.length === 1) {
+      val = parseInt(str, 10);
+    } else if (strict || /[89]/.test(str)) {
+      raise(start, "Invalid number");
+    } else {
+      val = parseInt(str, 8);
+    }
     return finishToken(_num, val);
   }
 
@@ -850,6 +1170,31 @@
   function readString(quote) {
     tokPos++;
     var out = "";
+    var helper = function () {
+      switch (ch) {
+        case 110: return "\n"; // 'n' -> '\n'
+        case 114: return "\r"; // 'r' -> '\r'
+        case 120: return String.fromCharCode(readHexChar(2)); // 'x'
+        case 117: return String.fromCharCode(readHexChar(4)); // 'u'
+        case 85:  return String.fromCharCode(readHexChar(8)); // 'U'
+        case 116: return "\t";     // 't' -> '\t'
+        case 98:  return "\b";     // 'b' -> '\b'
+        case 118: return "\u000b"; // 'v' -> '\u000b'
+        case 102: return  "\f";    // 'f' -> '\f'
+        case 48:  return "\0";     // 0 -> '\0'
+        case 13: // '\r\n'
+          if (input.charCodeAt(tokPos) === 10) ++tokPos;
+          return '';
+        case 10: // ' \n'
+          if (options.locations) {
+            tokLineStart = tokPos;
+            ++tokCurLine;
+          }
+          return '';
+        default: return String.fromCharCode(ch);
+      }
+    };
+    
     for (;;) {
       if (tokPos >= inputLen) raise(tokStart, "Unterminated string constant");
       var ch = input.charCodeAt(tokPos);
@@ -869,26 +1214,16 @@
           out += String.fromCharCode(parseInt(octal, 8));
           tokPos += octal.length - 1;
         } else {
-          switch (ch) {
-          case 110: out += "\n"; break; // 'n' -> '\n'
-          case 114: out += "\r"; break; // 'r' -> '\r'
-          case 120: out += String.fromCharCode(readHexChar(2)); break; // 'x'
-          case 117: out += String.fromCharCode(readHexChar(4)); break; // 'u'
-          case 85: out += String.fromCharCode(readHexChar(8)); break; // 'U'
-          case 116: out += "\t"; break; // 't' -> '\t'
-          case 98: out += "\b"; break; // 'b' -> '\b'
-          case 118: out += "\u000b"; break; // 'v' -> '\u000b'
-          case 102: out += "\f"; break; // 'f' -> '\f'
-          case 48: out += "\0"; break; // 0 -> '\0'
-          case 13: if (input.charCodeAt(tokPos) === 10) ++tokPos; // '\r\n'
-          case 10: // ' \n'
-            if (options.locations) { tokLineStart = tokPos; ++tokCurLine; }
-            break;
-          default: out += String.fromCharCode(ch); break;
-          }
+          out += helper();
         }
       } else {
-        if (ch === 13 || ch === 10 || ch === 8232 || ch === 8233) raise(tokStart, "Unterminated string constant");
+        switch (ch) {
+          case 10:
+          case 13:
+          case 8232:
+          case 8233:
+            raise(tokStart, "Unterminated string constant");
+        }
         out += String.fromCharCode(ch); // '\'
         ++tokPos;
       }
@@ -899,7 +1234,10 @@
 
   function readHexChar(len) {
     var n = readInt(16, len);
-    if (n === null) raise(tokStart, "Bad character escape sequence");
+    
+    if (isNull(n))
+      raise(tokStart, "Bad character escape sequence");
+    
     return n;
   }
 
@@ -917,21 +1255,32 @@
 
   function readWord1() {
     containsEsc = false;
-    var word, first = true, start = tokPos;
+    
+    var first = true;
+    var start = tokPos;
+    var word;
+    
     for (;;) {
       var ch = input.charCodeAt(tokPos);
       if (isIdentifierChar(ch)) {
         if (containsEsc) word += input.charAt(tokPos);
         ++tokPos;
       } else if (ch === 92) { // "\"
-        if (!containsEsc) word = input.slice(start, tokPos);
+        if (!containsEsc)
+          word = input.slice(start, tokPos);
+        
         containsEsc = true;
-        if (input.charCodeAt(++tokPos) != 117) // "u"
+        
+        if (input.charCodeAt(++tokPos) !== 117) // "u"
           raise(tokPos, "Expecting Unicode escape sequence \\uXXXX");
+        
         ++tokPos;
+        
         var esc = readHexChar(4);
         var escStr = String.fromCharCode(esc);
-        if (!escStr) raise(tokPos - 1, "Invalid Unicode escape");
+        
+        if (!escStr)
+          raise(tokPos - 1, "Invalid Unicode escape");
         if (!(first ? isIdentifierStart(esc) : isIdentifierChar(esc)))
           raise(tokPos - 4, "Invalid Unicode escape");
         word += escStr;
@@ -949,8 +1298,10 @@
   function readWord() {
     var word = readWord1();
     var type = _name;
+    
     if (!containsEsc && isKeyword(word))
       type = keywordTypes[word];
+    
     return finishToken(type, word);
   }
 
@@ -991,12 +1342,14 @@
   function setStrict(strct) {
     strict = strct;
     tokPos = tokStart;
+    
     if (options.locations) {
       while (tokPos < tokLineStart) {
         tokLineStart = input.lastIndexOf("\n", tokLineStart - 2) + 1;
         --tokCurLine;
       }
     }
+    
     skipSpace();
     readToken();
   }
@@ -1014,17 +1367,23 @@
   function SourceLocation() {
     this.start = tokStartLoc;
     this.end = null;
-    if (sourceFile !== null) this.source = sourceFile;
+    
+    if (!isNull(sourceFile)) 
+      this.source = sourceFile;
   }
 
   function startNode() {
     var node = new Node();
+    
     if (options.locations)
       node.loc = new SourceLocation();
+    
     if (options.directSourceFile)
       node.sourceFile = options.directSourceFile;
+    
     if (options.ranges)
       node.range = [tokStart, 0];
+    
     return node;
   }
 
@@ -1034,14 +1393,17 @@
 
   function startNodeFrom(other) {
     var node = new Node();
+    
     node.start = other.start;
+    
     if (options.locations) {
       node.loc = new SourceLocation();
       node.loc.start = other.loc.start;
     }
+    
     if (options.ranges)
       node.range = [other.range[0], 0];
-
+    
     return node;
   }
 
@@ -1050,18 +1412,23 @@
   function finishNode(node, type) {
     node.type = type;
     node.end = lastEnd;
+    
     if (options.locations)
       node.loc.end = lastEndLoc;
+    
     if (options.ranges)
       node.range[1] = lastEnd;
+    
     return node;
   }
 
   // Test whether a statement node is the string literal `"use strict"`.
 
   function isUseStrict(stmt) {
-    return options.ecmaVersion >= 5 && stmt.type === "ExpressionStatement" &&
-      stmt.expression.type === "Literal" && stmt.expression.value === "use strict";
+    return (options.ecmaVersion >= 5 &&
+            stmt.type === "ExpressionStatement" &&
+            stmt.expression.type === "Literal" &&
+            stmt.expression.value === "use strict");
   }
 
   // Predicate that tests whether the next token is of the given
@@ -1078,22 +1445,27 @@
 
   function canInsertSemicolon() {
     return !options.strictSemicolons &&
-      (tokType === _eof || tokType === _braceR || newline.test(input.slice(lastEnd, tokStart)));
+      (tokType === _eof ||
+       tokType === _braceR ||
+       newline.test(input.slice(lastEnd, tokStart)));
   }
 
   // Consume a semicolon, or, failing that, see if we are allowed to
   // pretend that there is a semicolon at this position.
 
   function semicolon() {
-    if (!eat(_semi) && !canInsertSemicolon()) unexpected();
+    if (!eat(_semi) && !canInsertSemicolon())
+      unexpected();
   }
 
   // Expect a token of a given type. If found, consume it, otherwise,
   // raise an unexpected token error.
 
   function expect(type) {
-    if (tokType === type) next();
-    else unexpected();
+    if (tokType !== type)
+      unexpected();
+    
+    next();
   }
 
   // Raise an unexpected token error.
@@ -1108,7 +1480,10 @@
   function checkLVal(expr) {
     if (expr.type !== "Identifier" && expr.type !== "MemberExpression")
       raise(expr.start, "Assigning to rvalue");
-    if (strict && expr.type === "Identifier" && isStrictBadIdWord(expr.name))
+    
+    if (strict &&
+        expr.type === "Identifier" &&
+        isStrictBadIdWord(expr.name))
       raise(expr.start, "Assigning to " + expr.name + " in strict mode");
   }
 
@@ -1121,13 +1496,25 @@
 
   function parseTopLevel(program) {
     lastStart = lastEnd = tokPos;
-    if (options.locations) lastEndLoc = new Position;
+    
+    if (options.locations)
+      lastEndLoc = new Position;
+    
     inFunction = strict = null;
     labels = [];
+    
     readToken();
-
-    var node = program || startNode(), first = true;
-    if (!program) node.body = [];
+    
+    var node;
+    if (program) {
+      node = program;
+    } else {
+      node = startNode();
+      node.body = [];
+    }
+    
+    var first = true;
+    
     while (tokType !== _eof) {
       var stmt = parseStatement();
       node.body.push(stmt);
@@ -1137,7 +1524,8 @@
     return finishNode(node, "Program");
   }
 
-  var loopLabel = {kind: "loop"}, switchLabel = {kind: "switch"};
+  var loopLabel = { kind: "loop" };
+  var switchLabel = { kind: "switch" };
 
   // Parse a single statement.
   //
@@ -1150,231 +1538,284 @@
     if (tokType === _slash || tokType === _assign && tokVal == "/=")
       readToken(true);
 
-    var starttype = tokType, node = startNode();
+    var starttype = tokType;
+    var node = startNode();
 
     // Most types of statements are recognized by the keyword they
     // start with. Many are trivial to parse, some require a bit of
     // complexity.
 
     switch (starttype) {
-    case _break: case _continue:
-      next();
-      var isBreak = starttype === _break;
-      if (eat(_semi) || canInsertSemicolon()) node.label = null;
-      else if (tokType !== _name) unexpected();
-      else {
-        node.label = parseIdent();
-        semicolon();
-      }
-
-      // Verify that there is an actual destination to break or
-      // continue to.
-      for (var i = 0; i < labels.length; ++i) {
-        var lab = labels[i];
-        if (node.label == null || lab.name === node.label.name) {
-          if (lab.kind != null && (isBreak || lab.kind === "loop")) break;
-          if (node.label && isBreak) break;
-        }
-      }
-      if (i === labels.length) raise(node.start, "Unsyntactic " + starttype.keyword);
-      return finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
-
-    case _debugger:
-      next();
-      semicolon();
-      return finishNode(node, "DebuggerStatement");
-
-    case _do:
-      next();
-      labels.push(loopLabel);
-      node.body = parseStatement();
-      labels.pop();
-      expect(_while);
-      node.test = parseParenExpression();
-      semicolon();
-      return finishNode(node, "DoWhileStatement");
-
-      // Disambiguating between a `for` and a `for`/`in` loop is
-      // non-trivial. Basically, we have to parse the init `var`
-      // statement or expression, disallowing the `in` operator (see
-      // the second parameter to `parseExpression`), and then check
-      // whether the next token is `in`. When there is no init part
-      // (semicolon immediately after the opening parenthesis), it is
-      // a regular `for` loop.
-
-    case _for:
-      next();
-      labels.push(loopLabel);
-      expect(_parenL);
-      if (tokType === _semi) return parseFor(node, null);
-      if (tokType === _var) {
-        var init = startNode();
+      case _break:
+      case _continue:
         next();
-        parseVar(init, true);
-        finishNode(init, "VariableDeclaration");
-        if (init.declarations.length === 1 && eat(_in))
-          return parseForIn(node, init);
-        return parseFor(node, init);
-      }
-      var init = parseExpression(false, true);
-      if (eat(_in)) {checkLVal(init); return parseForIn(node, init);}
-      return parseFor(node, init);
-
-    case _function:
-      next();
-      return parseFunction(node, true);
-
-    case _if:
-      next();
-      node.test = parseParenExpression();
-      node.consequent = parseStatement();
-      node.alternate = eat(_else) ? parseStatement() : null;
-      return finishNode(node, "IfStatement");
-
-    case _return:
-      if (!inFunction && !options.allowReturnOutsideFunction)
-        raise(tokStart, "'return' outside of function");
-      next();
-
-      // In `return` (and `break`/`continue`), the keywords with
-      // optional arguments, we eagerly look for a semicolon or the
-      // possibility to insert one.
-
-      if (eat(_semi) || canInsertSemicolon()) node.argument = null;
-      else { node.argument = parseExpression(); semicolon(); }
-      return finishNode(node, "ReturnStatement");
-
-    case _switch:
-      next();
-      node.discriminant = parseParenExpression();
-      node.cases = [];
-      expect(_braceL);
-      labels.push(switchLabel);
-
-      // Statements under must be grouped (by label) in SwitchCase
-      // nodes. `cur` is used to keep the node that we are currently
-      // adding statements to.
-
-      for (var cur, sawDefault; tokType != _braceR;) {
-        if (tokType === _case || tokType === _default) {
-          var isCase = tokType === _case;
-          if (cur) finishNode(cur, "SwitchCase");
-          node.cases.push(cur = startNode());
-          cur.consequent = [];
-          next();
-          if (isCase) cur.test = parseExpression();
-          else {
-            if (sawDefault) raise(lastStart, "Multiple default clauses"); sawDefault = true;
-            cur.test = null;
-          }
-          expect(_colon);
+        var isBreak = (starttype === _break);
+        if (eat(_semi) || canInsertSemicolon()) {
+          node.label = null;
+        } else if (tokType !== _name) {
+          unexpected();
         } else {
-          if (!cur) unexpected();
-          cur.consequent.push(parseStatement());
+          node.label = parseIdent();
+          semicolon();
         }
-      }
-      if (cur) finishNode(cur, "SwitchCase");
-      next(); // Closing brace
-      labels.pop();
-      return finishNode(node, "SwitchStatement");
-
-    case _throw:
-      next();
-      if (newline.test(input.slice(lastEnd, tokStart)))
-        raise(lastEnd, "Illegal newline after throw");
-      node.argument = parseExpression();
-      semicolon();
-      return finishNode(node, "ThrowStatement");
-
-    case _try:
-      next();
-      node.block = parseBlock();
-      node.handler = null;
-      if (tokType === _catch) {
-        var clause = startNode();
+        
+        // Verify that there is an actual destination to break or
+        // continue to.
+        for (var i = 0; i < labels.length; ++i) {
+          var lab = labels[i];
+          var label = node.label;
+          if (isNull(label) || lab.name === label.name) {
+            if (!isNull(lab.kind) && (isBreak || lab.kind === "loop") || 
+                label && isBreak)
+              break;
+          }
+        }
+        if (i === labels.length)
+          raise(node.start, "Unsyntactic " + starttype.keyword);
+        return finishNode(node, isBreak ? "BreakStatement" : "ContinueStatement");
+        
+      case _debugger:
         next();
-        expect(_parenL);
-        clause.param = parseIdent();
-        if (strict && isStrictBadIdWord(clause.param.name))
-          raise(clause.param.start, "Binding " + clause.param.name + " in strict mode");
-        expect(_parenR);
-        clause.guard = null;
-        clause.body = parseBlock();
-        node.handler = finishNode(clause, "CatchClause");
-      }
-      node.guardedHandlers = empty;
-      node.finalizer = eat(_finally) ? parseBlock() : null;
-      if (!node.handler && !node.finalizer)
-        raise(node.start, "Missing catch or finally clause");
-      return finishNode(node, "TryStatement");
-
-    case _var:
-      next();
-      parseVar(node);
-      semicolon();
-      return finishNode(node, "VariableDeclaration");
-
-    case _while:
-      next();
-      node.test = parseParenExpression();
-      labels.push(loopLabel);
-      node.body = parseStatement();
-      labels.pop();
-      return finishNode(node, "WhileStatement");
-
-    case _with:
-      if (strict) raise(tokStart, "'with' in strict mode");
-      next();
-      node.object = parseParenExpression();
-      node.body = parseStatement();
-      return finishNode(node, "WithStatement");
-
-    case _braceL:
-      return parseBlock();
-
-    case _semi:
-      next();
-      return finishNode(node, "EmptyStatement");
-
-      // If the statement does not start with a statement keyword or a
-      // brace, it's an ExpressionStatement or LabeledStatement. We
-      // simply start parsing an expression, and afterwards, if the
-      // next token is a colon and the expression was a simple
-      // Identifier node, we switch to interpreting it as a label.
-
-    default:
-      var maybeName = tokVal, expr = parseExpression();
-      if (starttype === _name && expr.type === "Identifier" && eat(_colon)) {
-        for (var i = 0; i < labels.length; ++i)
-          if (labels[i].name === maybeName) raise(expr.start, "Label '" + maybeName + "' is already declared");
-        var kind = tokType.isLoop ? "loop" : tokType === _switch ? "switch" : null;
-        labels.push({name: maybeName, kind: kind});
+        semicolon();
+        return finishNode(node, "DebuggerStatement");
+        
+      case _do:
+        next();
+        labels.push(loopLabel);
         node.body = parseStatement();
         labels.pop();
-        node.label = expr;
-        return finishNode(node, "LabeledStatement");
-      } else {
-        node.expression = expr;
+        expect(_while);
+        node.test = parseParenExpression();
         semicolon();
-        return finishNode(node, "ExpressionStatement");
-      }
+        return finishNode(node, "DoWhileStatement");
+        
+        // Disambiguating between a `for` and a `for`/`in` loop is
+        // non-trivial. Basically, we have to parse the init `var`
+        // statement or expression, disallowing the `in` operator (see
+        // the second parameter to `parseExpression`), and then check
+        // whether the next token is `in`. When there is no init part
+        // (semicolon immediately after the opening parenthesis), it is
+        // a regular `for` loop.
+        
+      case _for:
+        next();
+        labels.push(loopLabel);
+        expect(_parenL);
+        
+        if (tokType === _semi)
+          return parseFor(node, null);
+        
+        if (tokType === _var) {
+          var init = startNode();
+          next();
+          parseVar(init, true);
+          finishNode(init, "VariableDeclaration");
+          if (init.declarations.length === 1 && eat(_in))
+            return parseForIn(node, init);
+          return parseFor(node, init);
+        }
+        
+        var init = parseExpression(false, true);
+        
+        if (eat(_in)) {
+          checkLVal(init);
+          return parseForIn(node, init);
+        }
+        
+        return parseFor(node, init);
+        
+      case _function:
+        next();
+        return parseFunction(node, true);
+        
+      case _if:
+        next();
+        node.test = parseParenExpression();
+        node.consequent = parseStatement();
+        node.alternate = eat(_else) ? parseStatement() : null;
+        return finishNode(node, "IfStatement");
+        
+      case _return:
+        if (!inFunction && !options.allowReturnOutsideFunction)
+          raise(tokStart, "'return' outside of function");
+        
+        next();
+        
+        // In `return` (and `break`/`continue`), the keywords with
+        // optional arguments, we eagerly look for a semicolon or the
+        // possibility to insert one.
+        
+        if (eat(_semi) || canInsertSemicolon()) {
+          node.argument = null;
+        } else {
+          node.argument = parseExpression();
+          semicolon();
+        }
+        return finishNode(node, "ReturnStatement");
+        
+      case _switch:
+        next();
+        node.discriminant = parseParenExpression();
+        node.cases = [];
+        expect(_braceL);
+        labels.push(switchLabel);
+  
+        // Statements under must be grouped (by label) in SwitchCase
+        // nodes. `cur` is used to keep the node that we are currently
+        // adding statements to.
+  
+        for (var cur, sawDefault; tokType != _braceR;) {
+          if (tokType === _case || tokType === _default) {
+            if (cur) finishNode(cur, "SwitchCase");
+            node.cases.push(cur = startNode());
+            cur.consequent = [];
+            next();
+            if (tokType === _case) {
+              cur.test = parseExpression();
+            } else {
+              if (sawDefault)
+                raise(lastStart, "Multiple default clauses"); sawDefault = true;
+              
+              cur.test = null;
+            }
+            expect(_colon);
+          } else {
+            if (!cur)
+              unexpected();
+            
+            cur.consequent.push(parseStatement());
+          }
+        }
+        if (cur)
+          finishNode(cur, "SwitchCase");
+        
+        next(); // Closing brace
+        
+        labels.pop();
+        return finishNode(node, "SwitchStatement");
+        
+      case _throw:
+        next();
+        
+        if (newline.test(input.slice(lastEnd, tokStart)))
+          raise(lastEnd, "Illegal newline after throw");
+        
+        node.argument = parseExpression();
+        semicolon();
+        return finishNode(node, "ThrowStatement");
+        
+      case _try:
+        next();
+        
+        node.block = parseBlock();
+        node.handler = null;
+        
+        if (tokType === _catch) {
+          var clause = startNode();
+          
+          next();
+          expect(_parenL);
+          clause.param = parseIdent();
+          
+          if (strict && isStrictBadIdWord(clause.param.name))
+            raise(clause.param.start, "Binding " + clause.param.name + " in strict mode");
+          
+          expect(_parenR);
+          clause.guard = null;
+          clause.body = parseBlock();
+          node.handler = finishNode(clause, "CatchClause");
+        }
+        
+        node.guardedHandlers = empty;
+        node.finalizer = eat(_finally) ? parseBlock() : null;
+        
+        if (!node.handler && !node.finalizer)
+          raise(node.start, "Missing catch or finally clause");
+        
+        return finishNode(node, "TryStatement");
+        
+      case _var:
+        next();
+        parseVar(node);
+        semicolon();
+        return finishNode(node, "VariableDeclaration");
+        
+      case _while:
+        next();
+        
+        node.test = parseParenExpression();
+        labels.push(loopLabel);
+        
+        node.body = parseStatement();
+        labels.pop();
+        
+        return finishNode(node, "WhileStatement");
+        
+      case _with:
+        if (strict)
+          raise(tokStart, "'with' in strict mode");
+        
+        next();
+        
+        node.object = parseParenExpression();
+        node.body = parseStatement();
+        
+        return finishNode(node, "WithStatement");
+        
+      case _braceL:
+        return parseBlock();
+        
+      case _semi:
+        next();
+        return finishNode(node, "EmptyStatement");
+        
+        // If the statement does not start with a statement keyword or a
+        // brace, it's an ExpressionStatement or LabeledStatement. We
+        // simply start parsing an expression, and afterwards, if the
+        // next token is a colon and the expression was a simple
+        // Identifier node, we switch to interpreting it as a label.
+        
+      default:
+        var maybeName = tokVal, expr = parseExpression();
+        if (starttype === _name &&
+            expr.type === "Identifier" &&
+            eat(_colon)) {
+          for (var i = 0; i < labels.length; ++i) {
+            if (labels[i].name === maybeName)
+              raise(expr.start, "Label '" + maybeName + "' is already declared");
+          }
+          
+          var kind = tokType.isLoop ? "loop" : tokType === _switch ? "switch" : null;
+          
+          labels.push({ name: maybeName, kind: kind });
+          node.body = parseStatement();
+          
+          labels.pop();
+          node.label = expr;
+          
+          return finishNode(node, "LabeledStatement");
+        } else {
+          node.expression = expr;
+          semicolon();
+          return finishNode(node, "ExpressionStatement");
+        }
     }
   }
-
+  
   // Used for constructs like `switch` and `if` that insist on
   // parentheses around their expression.
-
+  
   function parseParenExpression() {
     expect(_parenL);
     var val = parseExpression();
     expect(_parenR);
     return val;
   }
-
+  
   // Parse a semicolon-enclosed block of statements, handling `"use
   // strict"` declarations when `allowStrict` is true (used for
   // function bodies).
-
+  
   function parseBlock(allowStrict) {
     var node = startNode(), first = true, strict = false, oldStrict;
     node.body = [];
@@ -1382,34 +1823,44 @@
     while (!eat(_braceR)) {
       var stmt = parseStatement();
       node.body.push(stmt);
-      if (first && allowStrict && isUseStrict(stmt)) {
+      if (first &&
+          allowStrict &&
+          isUseStrict(stmt)) {
         oldStrict = strict;
         setStrict(strict = true);
       }
       first = false;
     }
-    if (strict && !oldStrict) setStrict(false);
+    
+    if (strict && !oldStrict)
+      setStrict(false);
+    
     return finishNode(node, "BlockStatement");
   }
-
+  
   // Parse a regular `for` loop. The disambiguation code in
   // `parseStatement` will already have parsed the init statement or
   // expression.
-
+  
   function parseFor(node, init) {
     node.init = init;
+    
     expect(_semi);
-    node.test = tokType === _semi ? null : parseExpression();
+    node.test = (tokType === _semi) ? null : parseExpression();
+    
     expect(_semi);
-    node.update = tokType === _parenR ? null : parseExpression();
+    node.update = (tokType === _parenR) ? null : parseExpression();
+    
     expect(_parenR);
     node.body = parseStatement();
+    
     labels.pop();
+    
     return finishNode(node, "ForStatement");
   }
-
+  
   // Parse a `for`/`in` loop.
-
+  
   function parseForIn(node, init) {
     node.left = init;
     node.right = parseExpression();
@@ -1418,21 +1869,26 @@
     labels.pop();
     return finishNode(node, "ForInStatement");
   }
-
+  
   // Parse a list of variable declarations.
-
+  
   function parseVar(node, noIn) {
     node.declarations = [];
     node.kind = "var";
+    
     for (;;) {
       var decl = startNode();
       decl.id = parseIdent();
+      
       if (strict && isStrictBadIdWord(decl.id.name))
         raise(decl.id.start, "Binding " + decl.id.name + " in strict mode");
-      decl.init = eat(_eq) ? parseExpression(true, noIn) : null;
+      
+      decl.init = (eat(_eq)) ? parseExpression(true, noIn) : null;
       node.declarations.push(finishNode(decl, "VariableDeclarator"));
+      
       if (!eat(_comma)) break;
     }
+    
     return node;
   }
 
@@ -1450,12 +1906,19 @@
 
   function parseExpression(noComma, noIn) {
     var expr = parseMaybeAssign(noIn);
+    
     if (!noComma && tokType === _comma) {
       var node = startNodeFrom(expr);
+      
       node.expressions = [expr];
-      while (eat(_comma)) node.expressions.push(parseMaybeAssign(noIn));
+      
+      while (eat(_comma)) {
+        node.expressions.push(parseMaybeAssign(noIn));
+      }
+      
       return finishNode(node, "SequenceExpression");
     }
+    
     return expr;
   }
 
@@ -1464,31 +1927,35 @@
 
   function parseMaybeAssign(noIn) {
     var left = parseMaybeConditional(noIn);
-    if (tokType.isAssign) {
-      var node = startNodeFrom(left);
-      node.operator = tokVal;
-      node.left = left;
-      next();
-      node.right = parseMaybeAssign(noIn);
-      checkLVal(left);
-      return finishNode(node, "AssignmentExpression");
-    }
-    return left;
+    
+    if (!tokType.isAssign) return left;
+    
+    var node = startNodeFrom(left);
+    node.operator = tokVal;
+    node.left = left;
+    
+    next();
+    node.right = parseMaybeAssign(noIn);
+    
+    checkLVal(left);
+    
+    return finishNode(node, "AssignmentExpression");
   }
 
   // Parse a ternary conditional (`?:`) operator.
 
   function parseMaybeConditional(noIn) {
     var expr = parseExprOps(noIn);
-    if (eat(_question)) {
-      var node = startNodeFrom(expr);
-      node.test = expr;
-      node.consequent = parseExpression(true);
-      expect(_colon);
-      node.alternate = parseExpression(true, noIn);
-      return finishNode(node, "ConditionalExpression");
-    }
-    return expr;
+    if (!eat(_question)) return expr;
+    
+    var node = startNodeFrom(expr);
+    node.test = expr;
+    node.consequent = parseExpression(true);
+    
+    expect(_colon);
+    node.alternate = parseExpression(true, noIn);
+    
+    return finishNode(node, "ConditionalExpression");
   }
 
   // Start the precedence parser.
@@ -1505,35 +1972,46 @@
 
   function parseExprOp(left, minPrec, noIn) {
     var prec = tokType.binop;
-    if (prec != null && (!noIn || tokType !== _in)) {
-      if (prec > minPrec) {
-        var node = startNodeFrom(left);
-        node.left = left;
-        node.operator = tokVal;
-        var op = tokType;
-        next();
-        node.right = parseExprOp(parseMaybeUnary(), prec, noIn);
-        var exprNode = finishNode(node, (op === _logicalOR || op === _logicalAND) ? "LogicalExpression" : "BinaryExpression");
-        return parseExprOp(exprNode, minPrec, noIn);
-      }
-    }
-    return left;
+    if (isNull(prec) || (noIn && tokType === _in) || prec <= minPrec)
+      return left;
+    
+    var node = startNodeFrom(left);
+    node.left = left;
+    node.operator = tokVal;
+    
+    var op = tokType;
+    
+    next();
+    
+    node.right = parseExprOp(parseMaybeUnary(), prec, noIn);
+    
+    var exprNode = finishNode(node, (op === _logicalOR || op === _logicalAND) ? "LogicalExpression" : "BinaryExpression");
+    
+    return parseExprOp(exprNode, minPrec, noIn);
   }
-
+  
   // Parse unary operators, both prefix and postfix.
-
+  
   function parseMaybeUnary() {
     if (tokType.prefix) {
       var node = startNode(), update = tokType.isUpdate;
       node.operator = tokVal;
       node.prefix = true;
+      
       tokRegexpAllowed = true;
+      
       next();
+      
       node.argument = parseMaybeUnary();
-      if (update) checkLVal(node.argument);
-      else if (strict && node.operator === "delete" &&
-               node.argument.type === "Identifier")
+      
+      if (update) {
+        checkLVal(node.argument);
+      } else if (strict &&
+                 node.operator === "delete" &&
+                 node.argument.type === "Identifier") {
         raise(node.start, "Deleting local variable in strict mode");
+      }
+      
       return finishNode(node, update ? "UpdateExpression" : "UnaryExpression");
     }
     var expr = parseExprSubscripts();
@@ -1542,100 +2020,126 @@
       node.operator = tokVal;
       node.prefix = false;
       node.argument = expr;
+      
       checkLVal(expr);
+      
       next();
+      
       expr = finishNode(node, "UpdateExpression");
     }
+    
     return expr;
   }
-
+  
   // Parse call, dot, and `[]`-subscript expressions.
-
+  
   function parseExprSubscripts() {
     return parseSubscripts(parseExprAtom());
   }
-
+  
   function parseSubscripts(base, noCalls) {
     if (eat(_dot)) {
       var node = startNodeFrom(base);
+      
       node.object = base;
       node.property = parseIdent(true);
       node.computed = false;
+      
       return parseSubscripts(finishNode(node, "MemberExpression"), noCalls);
     } else if (eat(_bracketL)) {
       var node = startNodeFrom(base);
+      
       node.object = base;
       node.property = parseExpression();
       node.computed = true;
+      
       expect(_bracketR);
+      
       return parseSubscripts(finishNode(node, "MemberExpression"), noCalls);
     } else if (!noCalls && eat(_parenL)) {
       var node = startNodeFrom(base);
+      
       node.callee = base;
       node.arguments = parseExprList(_parenR, false);
+      
       return parseSubscripts(finishNode(node, "CallExpression"), noCalls);
-    } else return base;
+    } else {
+      return base;
+    }
   }
-
+  
   // Parse an atomic expression — either a single token that is an
   // expression, an expression started by a keyword like `function` or
   // `new`, or an expression wrapped in punctuation like `()`, `[]`,
   // or `{}`.
-
+  
   function parseExprAtom() {
     switch (tokType) {
     case _this:
       var node = startNode();
       next();
       return finishNode(node, "ThisExpression");
+      
     case _name:
       return parseIdent();
-    case _num: case _string: case _regexp:
+      
+    case _num:
+    case _string:
+    case _regexp:
       var node = startNode();
       node.value = tokVal;
       node.raw = input.slice(tokStart, tokEnd);
       next();
       return finishNode(node, "Literal");
-
-    case _null: case _true: case _false:
+      
+    case _null:
+    case _true:
+    case _false:
       var node = startNode();
       node.value = tokType.atomValue;
       node.raw = tokType.keyword;
       next();
       return finishNode(node, "Literal");
-
+      
     case _parenL:
-      var tokStartLoc1 = tokStartLoc, tokStart1 = tokStart;
+      var tokStartLoc1 = tokStartLoc;
+      var tokStart1 = tokStart;
+      
       next();
+      
       var val = parseExpression();
+      
       val.start = tokStart1;
       val.end = tokEnd;
+      
       if (options.locations) {
         val.loc.start = tokStartLoc1;
         val.loc.end = tokEndLoc;
       }
+      
       if (options.ranges)
         val.range = [tokStart1, tokEnd];
+      
       expect(_parenR);
       return val;
-
+      
     case _bracketL:
       var node = startNode();
       next();
       node.elements = parseExprList(_bracketR, true, true);
       return finishNode(node, "ArrayExpression");
-
+      
     case _braceL:
       return parseObj();
-
+      
     case _function:
       var node = startNode();
       next();
       return parseFunction(node, false);
-
+      
     case _new:
       return parseNew();
-
+      
     default:
       unexpected();
     }
@@ -1647,37 +2151,53 @@
 
   function parseNew() {
     var node = startNode();
+    
     next();
+    
     node.callee = parseSubscripts(parseExprAtom(), true);
-    if (eat(_parenL)) node.arguments = parseExprList(_parenR, false);
-    else node.arguments = empty;
+    
+    node.arguments = (eat(_parenL)) ? parseExprList(_parenR, false) : empty;
+    
     return finishNode(node, "NewExpression");
   }
-
+  
   // Parse an object literal.
-
+  
   function parseObj() {
-    var node = startNode(), first = true, sawGetSet = false;
+    var node = startNode();
+    var first = true;
+    var sawGetSet = false;
+    
     node.properties = [];
+    
     next();
+    
     while (!eat(_braceR)) {
       if (!first) {
         expect(_comma);
-        if (options.allowTrailingCommas && eat(_braceR)) break;
-      } else first = false;
-
-      var prop = {key: parsePropertyName()}, isGetSet = false, kind;
+        if (options.allowTrailingCommas && eat(_braceR))
+          break;
+      }
+      first = false;
+      
+      var prop = { key: parsePropertyName() };
+      var isGetSet = false;
+      var kind;
+      
       if (eat(_colon)) {
         prop.value = parseExpression(true);
         kind = prop.kind = "init";
-      } else if (options.ecmaVersion >= 5 && prop.key.type === "Identifier" &&
+      } else if (options.ecmaVersion >= 5 &&
+                 prop.key.type === "Identifier" &&
                  (prop.key.name === "get" || prop.key.name === "set")) {
         isGetSet = sawGetSet = true;
         kind = prop.kind = prop.key.name;
         prop.key = parsePropertyName();
         if (tokType !== _parenL) unexpected();
         prop.value = parseFunction(startNode(), false);
-      } else unexpected();
+      } else {
+        unexpected();
+      }
 
       // getters and setters are not allowed to clash — either with
       // each other or with an init property — and in strict mode,
@@ -1686,11 +2206,26 @@
       if (prop.key.type === "Identifier" && (strict || sawGetSet)) {
         for (var i = 0; i < node.properties.length; ++i) {
           var other = node.properties[i];
+          
           if (other.key.name === prop.key.name) {
-            var conflict = kind == other.kind || isGetSet && other.kind === "init" ||
-              kind === "init" && (other.kind === "get" || other.kind === "set");
-            if (conflict && !strict && kind === "init" && other.kind === "init") conflict = false;
-            if (conflict) raise(prop.key.start, "Redefinition of property");
+            // simplify conditionals tremendously...small hack
+            switch (true) {
+              // only check if strict
+              case strict:
+                // if both are init properties
+                if (kind === other.kind === "init")
+                  raise(prop.key.start, "Redefinition of property");
+                
+                // if other is not getter/setter, don't fall through
+                if (other.kind !== "get" && other.kind !== "set") break;
+                
+                // fall through...
+                
+              // if other is getter/setter
+              case other.kind === "get" || other.kind === "set":
+                if (isGetSet || kind === "init")
+                  raise(prop.key.start, "Redefinition of property");
+            }
           }
         }
       }
@@ -1698,22 +2233,30 @@
     }
     return finishNode(node, "ObjectExpression");
   }
-
+  
   function parsePropertyName() {
-    if (tokType === _num || tokType === _string) return parseExprAtom();
+    if (tokType === _num || tokType === _string)
+      return parseExprAtom();
+    
     return parseIdent(true);
   }
-
+  
   // Parse a function declaration or literal (depending on the
   // `isStatement` parameter).
-
+  
   function parseFunction(node, isStatement) {
-    if (tokType === _name) node.id = parseIdent();
-    else if (isStatement) unexpected();
-    else node.id = null;
+    if (tokType === _name) {
+      node.id = parseIdent();
+    } else if (isStatement) {
+      unexpected();
+    } else {
+      node.id = null;
+    }
     node.params = [];
     node.rest = null;
+    
     expect(_parenL);
+    
     for (;;) {
       if (eat(_parenR)) {
         break;
@@ -1729,54 +2272,80 @@
         }
       }
     }
-
+    
     // Start a new scope with regard to labels and the `inFunction`
     // flag (restore them to their old value afterwards).
-    var oldInFunc = inFunction, oldLabels = labels;
-    inFunction = true; labels = [];
+    var oldInFunc = inFunction
+    var oldLabels = labels;
+    
+    inFunction = true;
+    labels = [];
+    
     node.body = parseBlock(true);
-    inFunction = oldInFunc; labels = oldLabels;
-
+    
+    inFunction = oldInFunc;
+    labels = oldLabels;
+    
     // If this is a strict mode function, verify that argument names
     // are not repeated, and it does not try to bind the words `eval`
     // or `arguments`.
     if (strict || node.body.body.length && isUseStrict(node.body.body[0])) {
-      for (var i = node.id ? -1 : 0; i < node.params.length; ++i) {
-        var id = i < 0 ? node.id : node.params[i];
+      var params = node.params;
+      var id, i, j;
+      if (node.id) {
+        id = node.id;
         if (isStrictReservedWord(id.name) || isStrictBadIdWord(id.name))
           raise(id.start, "Defining '" + id.name + "' in strict mode");
-        if (i >= 0) for (var j = 0; j < i; ++j) if (id.name === node.params[j].name)
-          raise(id.start, "Argument name clash in strict mode");
+      }
+      id = params[0];
+      
+      if (isStrictReservedWord(id.name) || isStrictBadIdWord(id.name))
+        raise(id.start, "Defining '" + id.name + "' in strict mode");
+      
+      for (i = params.length; i > 0; --i) {
+        id = params[i];
+        
+        if (isStrictReservedWord(id.name) || isStrictBadIdWord(id.name))
+          raise(id.start, "Defining '" + id.name + "' in strict mode");
+        
+        for (j = i; j >= 0; ) {
+          if (id.name === params[--j].name)
+            raise(id.start, "Argument name clash in strict mode");
+        }
       }
     }
 
     return finishNode(node, isStatement ? "FunctionDeclaration" : "FunctionExpression");
   }
-
+  
   // Parses a comma-separated list of expressions, and returns them as
   // an array. `close` is the token type that ends the list, and
   // `allowEmpty` can be turned on to allow subsequent commas with
   // nothing in between them to be parsed as `null` (which is needed
   // for array literals).
-
+  
   function parseExprList(close, allowTrailingComma, allowEmpty) {
-    var elts = [], first = true;
+    var elts = [];
+    var first = true;
     while (!eat(close)) {
       if (!first) {
         expect(_comma);
-        if (allowTrailingComma && options.allowTrailingCommas && eat(close)) break;
-      } else first = false;
+        if (allowTrailingComma &&
+            options.allowTrailingCommas &&
+            eat(close))
+          break;
+      }
+      first = false;
 
-      if (allowEmpty && tokType === _comma) elts.push(null);
-      else elts.push(parseExpression(true));
+      elts.push((allowEmpty && tokType === _comma) ? null : parseExpression(true));
     }
     return elts;
   }
-
+  
   // Parse the next token as an identifier. If `liberal` is true (used
   // when parsing properties), it will also convert keywords into
   // identifiers.
-
+  
   function parseIdent(liberal) {
     var node = startNode();
     if (liberal && options.forbidReserved == "everywhere") liberal = false;


### PR DESCRIPTION
Several cases of loop unrolling/switch instead of several if-else done. Far more efficient to use switch instead of several numerical conditionals. Should provide a boost to performance with the parsing.

Did plenty of other smaller optimizations and bug fixes such as `null === null` is false, whereas `isNull(null)` is true. Introduced a few helper functions.

Also did a lot of readability improvements/linting.

There are a few cases of subbing switch-case statements for if-else segments (it greatly simplified a conditional in a somewhat hackish way).
