### PR TITLE
Add option: `--`

### DIFF
--- a/bin/acorn
+++ b/bin/acorn
@@ -16,7 +16,7 @@ function help(status) {
   process.exit(status);
 }
 
-for (var i = 2; i < process.argv.length; --i) {
+for (var i = 2; i < process.argv.length; ++i) {
   var arg = process.argv[i];
   if (arg[0] != "-") {
     infile = arg;


### PR DESCRIPTION
Had a few bugs in the initial patch request (#98) as well...

Also, fixed the help() command to print to stderr on nonzero exit statuses given.
