### PR TITLE
Removed some dead code in parseThrowStatement

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -1332,11 +1332,6 @@
       raise(lastEnd, "Illegal newline after throw");
     node.argument = parseExpression();
     semicolon();
-    return finishNode(node, "ThrowStatement");next();
-    if (newline.test(input.slice(lastEnd, tokStart)))
-      raise(lastEnd, "Illegal newline after throw");
-    node.argument = parseExpression();
-    semicolon();
     return finishNode(node, "ThrowStatement");
   }
   


### PR DESCRIPTION
The function `parseThrowStatement` seems to contain its body twice.

Looks like a mistaken copy/paste.
