### PR TITLE
Do not throw syntax error if strict mode function has same name as one of its parameters.

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -2260,7 +2260,7 @@
     if (strict || !isExpression && node.body.body.length && isUseStrict(node.body.body[0])) {
       var nameHash = {};
       if (node.id)
-        checkFunctionParam(node.id, nameHash);
+        checkFunctionParam(node.id, {});
       for (var i = 0; i < node.params.length; i++)
         checkFunctionParam(node.params[i], nameHash);
       if (node.rest)

--- a/test/tests.js
+++ b/test/tests.js
@@ -28748,3 +28748,5 @@ testFail("for(const x = 0;;);", "Unexpected token (1:4)", {ecmaVersion: 6});
     }
   });
 })();
+
+test("function f(f) { 'use strict'; }", {});


### PR DESCRIPTION
Fixes https://github.com/marijnh/acorn/issues/121.
