### PR TITLE
Fixes #129 and spaces in template quasi literals.

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -2115,6 +2115,8 @@
       expect(_dollarBraceL);
       node.expressions.push(parseExpression());
       inTemplate = true;
+      // hack to include previously skipped space
+      tokPos = tokEnd;
       expect(_braceR);
     }
     inTemplate = false;
@@ -2270,13 +2272,17 @@
         node.rest = toAssignable(parseExprAtom(), false, true);
         checkSpreadAssign(node.rest);
         expect(_parenR);
+        defaults.push(null);
         break;
       } else {
         node.params.push(options.ecmaVersion >= 6 ? toAssignable(parseExprAtom(), false, true) : parseIdent());
-        if (options.ecmaVersion >= 6 && tokType === _eq) {
-          next();
-          hasDefaults = true;
-          defaults.push(parseExpression(true));
+        if (options.ecmaVersion >= 6) {
+          if (eat(_eq)) {
+            hasDefaults = true;
+            defaults.push(parseExpression(true));
+          } else {
+            defaults.push(null);
+          }
         }
         if (!eat(_comma)) {
           expect(_parenR);

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -15246,3 +15246,146 @@ testFail("\"use strict\"; (eval) => 42", "Defining 'eval' in strict mode (1:15)"
 testFail("(eval) => { \"use strict\"; 42 }", "Defining 'eval' in strict mode (1:1)", {ecmaVersion: 6});
 
 testFail("({ get test() { } }) => 42", "Unexpected token (1:7)", {ecmaVersion: 6});
+
+/* Regression tests */
+
+// # https://github.com/marijnh/acorn/issues/127
+test('doSmth(`${x} + ${y} = ${x + y}`)', {
+  type: "Program",
+  start: 0,
+  end: 32,
+  body: [{
+    type: "ExpressionStatement",
+    start: 0,
+    end: 32,
+    expression: {
+      type: "CallExpression",
+      start: 0,
+      end: 32,
+      callee: {
+        type: "Identifier",
+        start: 0,
+        end: 6,
+        name: "doSmth"
+      },
+      arguments: [{
+        type: "TemplateLiteral",
+        start: 7,
+        end: 31,
+        expressions: [
+          {
+            type: "Identifier",
+            start: 10,
+            end: 11,
+            name: "x"
+          },
+          {
+            type: "Identifier",
+            start: 17,
+            end: 18,
+            name: "y"
+          },
+          {
+            type: "BinaryExpression",
+            start: 24,
+            end: 29,
+            left: {
+              type: "Identifier",
+              start: 24,
+              end: 25,
+              name: "x"
+            },
+            operator: "+",
+            right: {
+              type: "Identifier",
+              start: 28,
+              end: 29,
+              name: "y"
+            }
+          }
+        ],
+        quasis: [
+          {
+            type: "TemplateElement",
+            start: 8,
+            end: 8,
+            value: {cooked: "", raw: ""},
+            tail: false
+          },
+          {
+            type: "TemplateElement",
+            start: 12,
+            end: 15,
+            value: {cooked: " + ", raw: " + "},
+            tail: false
+          },
+          {
+            type: "TemplateElement",
+            start: 19,
+            end: 22,
+            value: {cooked: " = ", raw: " = "},
+            tail: false
+          },
+          {
+            type: "TemplateElement",
+            start: 30,
+            end: 30,
+            value: {cooked: "", raw: ""},
+            tail: true
+          }
+        ]
+      }]
+    }
+  }]
+}, {ecmaVersion: 6});
+
+// # https://github.com/marijnh/acorn/issues/129
+test('function normal(x, y = 10) {}', {
+  type: "Program",
+  start: 0,
+  end: 29,
+  body: [{
+    type: "FunctionDeclaration",
+    start: 0,
+    end: 29,
+    id: {
+      type: "Identifier",
+      start: 9,
+      end: 15,
+      name: "normal"
+    },
+    params: [
+      {
+        type: "Identifier",
+        start: 16,
+        end: 17,
+        name: "x"
+      },
+      {
+        type: "Identifier",
+        start: 19,
+        end: 20,
+        name: "y"
+      }
+    ],
+    defaults: [
+      null,
+      {
+        type: "Literal",
+        start: 23,
+        end: 25,
+        value: 10,
+        raw: "10"
+      }
+    ],
+    rest: null,
+    generator: false,
+    body: {
+      type: "BlockStatement",
+      start: 27,
+      end: 29,
+      body: []
+    },
+    expression: false
+  }]
+}, {ecmaVersion: 6});


### PR DESCRIPTION
- Added hack to correctly handle skipped spaces after= template expressions.
- Added `null` default values for regular functions (fixes #129).
- Added regression tests for both.
