### PR TITLE
Only accept for-of loops in ECMA6 mode.

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -1584,13 +1584,13 @@
       next();
       parseVar(init, true, varKind);
       finishNode(init, "VariableDeclaration");
-      if ((tokType === _in || (tokType === _name && tokVal === "of")) && init.declarations.length === 1 &&
+      if ((tokType === _in || (options.ecmaVersion >= 6 && tokType === _name && tokVal === "of")) && init.declarations.length === 1 &&
           !(isLet && init.declarations[0].init))
         return parseForIn(node, init);
       return parseFor(node, init);
     }
     var init = parseExpression(false, true);
-    if (tokType === _in || (tokType === _name && tokVal === "of")) {
+    if (tokType === _in || (options.ecmaVersion >= 6 && tokType === _name && tokVal === "of")) {
       checkLVal(init);
       return parseForIn(node, init);
     }

--- a/test/tests.js
+++ b/test/tests.js
@@ -28594,6 +28594,10 @@ testFail("const a;", "Unexpected token (1:7)", {ecmaVersion: 6});
 
 testFail("for(const x = 0;;);", "Unexpected token (1:4)", {ecmaVersion: 6});
 
+testFail("for(x of a);", "Unexpected token (1:6)");
+
+testFail("for(var x of a);", "Unexpected token (1:10)");
+
 // Assertion Tests
 (function() {
   var actualComments = [],


### PR DESCRIPTION
Fixes https://github.com/marijnh/acorn/issues/131.
