### PR TITLE
Guard against missing elements in array patterns when checking function parameters.

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -1391,8 +1391,10 @@
         break;
 
       case "ArrayPattern":
-        for (var i = 0; i < param.elements.length; i++)
-          checkFunctionParam(param.elements[i], nameHash);
+        for (var i = 0; i < param.elements.length; i++) {
+          var elem = param.elements[i];
+          if (elem) checkFunctionParam(elem, nameHash);
+        }
         break;
     }
   }

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -15389,3 +15389,5 @@ test('function normal(x, y = 10) {}', {
     expression: false
   }]
 }, {ecmaVersion: 6});
+
+test("'use strict'; function f([x,,z]) {}", {}, {ecmaVersion: 6});


### PR DESCRIPTION
This previously caused an exception.
