### PR TITLE
Make ImportDeclaration and ExportDeclaration semicolons spec-compliant

### DIFF
--- a/acorn.js
+++ b/acorn.js
@@ -2482,8 +2482,8 @@
       node.source = null;
       semicolon();
     } else {
-      // export * from '...'
-      // export { x, y as z } [from '...']
+      // export * from '...';
+      // export { x, y as z } [from '...'];
       var isBatch = tokType === _star;
       node.declaration = null;
       node['default'] = false;
@@ -2495,6 +2495,7 @@
         if (isBatch) unexpected();
         node.source = null;
       }
+      semicolon();
     }
     return finishNode(node, "ExportDeclaration");
   }
@@ -2549,6 +2550,7 @@
       // (it doesn't support mixed default + named yet)
       node.kind = node.specifiers[0]['default'] ? "default" : "named";
     }
+    semicolon();
     return finishNode(node, "ImportDeclaration");
   }
 


### PR DESCRIPTION
`ImportDeclaration`s end with a semicolon and `ExportDeclaration`s with specifiers end with a semicolon.

Reference: [Ecma-262 Edition 6 Rev 28 Section - 15.2.2 and 15.2.3](http://wiki.ecmascript.org/lib/exe/fetch.php?id=harmony%3Aspecification_drafts&cache=cache&media=harmony:working_draft_ecma-262_edition_6_10-14-14-nomarkup.pdf).
