### PR TITLE
Walk fix

### DIFF
--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -253,7 +253,6 @@ base.ForInit = (node, st, c) => {
 base.DebuggerStatement = ignore
 
 base.Declaration = skipThrough
-base.FunctionDeclaration = (node, st, c) => c(node, st, "Function")
 base.VariableDeclaration = (node, st, c) => {
   for (let decl of node.declarations)
     c(decl, st)
@@ -263,6 +262,7 @@ base.VariableDeclarator = (node, st, c) => {
   if (node.init) c(node.init, st, "Expression")
 }
 
+base.FunctionExpression = base.ArrowFunctionExpression = base.FunctionDeclaration = (node, st, c) => c(node, st, "Function")
 base.Function = (node, st, c) => {
   for (let param of node.params)
     c(param, st, "Pattern")
@@ -301,7 +301,6 @@ base.ObjectExpression = (node, st, c) => {
   for (let prop of node.properties)
     c(prop, st)
 }
-base.FunctionExpression = base.ArrowFunctionExpression = base.FunctionDeclaration
 base.TemplateLiteral = (node, st, c) => {
   for (let quasi of node.quasis)
     c(quasi, st)

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -275,15 +275,11 @@ base.ScopeBody = (node, st, c) => c(node, st, "Statement")
 base.ScopeExpression = (node, st, c) => c(node, st, "Expression")
 
 base.Pattern = (node, st, c) => {
-  if (node.type == "Identifier")
-    c(node, st, "VariablePattern")
-  else if (node.type == "MemberExpression")
-    c(node, st, "MemberPattern")
+  if (node.type == "Identifier" || node.type === "MemberExpression")
+    c(node, st, "Expression")
   else
     c(node, st)
 }
-base.VariablePattern = ignore
-base.MemberPattern = skipThrough
 base.RestElement = (node, st, c) => c(node.argument, st, "Pattern")
 base.ArrayPattern = (node, st, c) => {
   for (let elt of node.elements) {

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -217,8 +217,11 @@ base.SwitchCase = (node, st, c) => {
   for (let cons of node.consequent)
     c(cons, st, "Statement")
 }
-base.ReturnStatement = base.YieldExpression = base.AwaitExpression = (node, st, c) => {
+base.ReturnStatement = base.YieldExpression = (node, st, c) => {
   if (node.argument) c(node.argument, st, "Expression")
+}
+base.AwaitExpression = (node, st, c) => {
+  c(node.argument, st, "Expression")
 }
 base.ThrowStatement = base.SpreadElement =
   (node, st, c) => c(node.argument, st, "Expression")

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -264,7 +264,6 @@ base.VariableDeclarator = (node, st, c) => {
 }
 
 base.Function = (node, st, c) => {
-  if (node.id) c(node.id, st, "Pattern")
   for (let param of node.params)
     c(param, st, "Pattern")
   c(node.body, st, node.expression ? "ScopeExpression" : "ScopeBody")

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -184,10 +184,13 @@ base.WithStatement = (node, st, c) => {
 base.SwitchStatement = (node, st, c) => {
   c(node.discriminant, st, "Expression")
   for (let cs of node.cases) {
-    if (cs.test) c(cs.test, st, "Expression")
-    for (let cons of cs.consequent)
-      c(cons, st, "Statement")
+    c(cs, st, "SwitchCase")
   }
+}
+base.SwitchCase = (node, st, c) => {
+  if (node.test) c(node.test, st, "Expression")
+  for (let cons of node.consequent)
+    c(cons, st, "Statement")
 }
 base.ReturnStatement = base.YieldExpression = base.AwaitExpression = (node, st, c) => {
   if (node.argument) c(node.argument, st, "Expression")

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -290,7 +290,7 @@ base.ArrayPattern = (node, st, c) => {
 }
 base.ObjectPattern = (node, st, c) => {
   for (let prop of node.properties)
-    c(prop.value, st, "Pattern")
+    c(prop.value, st, "Property")
 }
 
 base.Expression = skipThrough

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -193,7 +193,7 @@ base.Statement = (node, st, c) => {
   }
 }
 base.EmptyStatement = ignore
-base.ExpressionStatement = base.ParenthesizedExpression =
+base.ExpressionStatement = base.ParenthesizedExpression = base.Decorator =
   (node, st, c) => c(node.expression, st, "Expression")
 base.IfStatement = (node, st, c) => {
   c(node.test, st, "Expression")
@@ -404,6 +404,10 @@ base.Class = (node, st, c) => {
   if (node.id) c(node.id, st, "Pattern")
   if (node.superClass) c(node.superClass, st, "Expression")
   c(node.body, st, "ClassBody")
+  if (node.decorators) {
+    for (let decorator of node.decorators)
+      c(decorator, st)
+  }
 }
 base.ClassBody = (node, st, c) => {
   for (let item of node.body)
@@ -412,4 +416,8 @@ base.ClassBody = (node, st, c) => {
 base.MethodDefinition = base.Property = (node, st, c) => {
   if (node.computed) c(node.key, st, "Expression")
   c(node.value, st, "Expression")
+  if (node.decorators) {
+    for (let decorator of node.decorators)
+      c(decorator, st)
+  }
 }

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -281,7 +281,14 @@ base.ObjectExpression = (node, st, c) => {
     c(prop, st)
 }
 base.FunctionExpression = base.ArrowFunctionExpression = base.FunctionDeclaration
-base.SequenceExpression = base.TemplateLiteral = (node, st, c) => {
+base.TemplateLiteral = (node, st, c) => {
+  for (let quasi of node.quasis)
+    c(quasi, st)
+  for (let expr of node.expressions)
+    c(expr, st, "Expression")
+}
+base.TemplateElement = ignore
+base.SequenceExpression = (node, st, c) => {
   for (let expr of node.expressions)
     c(expr, st, "Expression")
 }

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -330,14 +330,28 @@ base.ConditionalExpression = (node, st, c) => {
   c(node.consequent, st, "Expression")
   c(node.alternate, st, "Expression")
 }
-base.NewExpression = base.CallExpression = (node, st, c) => {
+base.NewExpression = (node, st, c) => {
   c(node.callee, st, "Expression")
   if (node.arguments)
     for (let arg of node.arguments)
       c(arg, st, "Expression")
 }
+base.CallExpression = (node, st, c) => {
+  if (node.callee.type === "Super") {
+    c(node.callee, st)
+  } else {
+    c(node.callee, st, "Expression")
+  }
+  if (node.arguments)
+    for (let arg of node.arguments)
+      c(arg, st, "Expression")
+}
 base.MemberExpression = (node, st, c) => {
-  c(node.object, st, "Expression")
+  if (node.object.type === "Super") {
+    c(node.object, st)
+  } else {
+    c(node.object, st, "Expression")
+  }
   if (node.computed) c(node.property, st, "Expression")
 }
 base.ModuleDeclaration = skipThrough

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -339,6 +339,8 @@ base.ExportDefaultDeclaration = (node, st, c) => {
 base.ExportNamedDeclaration = (node, st, c) => {
   if (node.declaration)
     c(node.declaration, st, "Statement")
+  for (let spec of node.specifiers)
+    c(spec, st, "ModuleSpecifier")
   if (node.source) c(node.source, st, "Expression")
 }
 base.ExportAllDeclaration = (node, st, c) => {
@@ -350,7 +352,7 @@ base.ImportDeclaration = (node, st, c) => {
   c(node.source, st, "Expression")
 }
 base.ModuleSpecifier = skipThrough
-base.ImportSpecifier = base.ImportDefaultSpecifier = base.ImportNamespaceSpecifier = base.Identifier = base.Literal = ignore
+base.ImportSpecifier = base.ImportDefaultSpecifier = base.ImportNamespaceSpecifier = base.ExportSpecifier = base.Identifier = base.Literal = ignore
 
 base.TaggedTemplateExpression = (node, st, c) => {
   c(node.tag, st, "Expression")

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -162,15 +162,14 @@ function ignore(_node, _st, _c) {}
 
 export const base = {}
 
-const moduleDeclarationTypes = [
-  "ImportDeclaration",
-  "ExportNamedDeclaration",
-  "ExportDefaultDeclaration",
-  "ExportAllDeclaration"
-]
 base.Program = (node, st, c) => {
   for (let child of node.body)
-    if (moduleDeclarationTypes.includes(child.type)) {
+    if (
+      child.type === "ImportDeclaration" ||
+      child.type === "ExportNamedDeclaration" ||
+      child.type === "ExportDefaultDeclaration" ||
+      child.type === "ExportAllDeclaration"
+    ) {
       c(child, st, "ModuleDeclaration")
     } else {
       c(child, st, "Statement")
@@ -180,13 +179,12 @@ base.BlockStatement = (node, st, c) => {
   for (let child of node.body)
     c(child, st, "Statement")
 }
-const declarationTypes = [
-  "VariableDeclaration",
-  "FunctionDeclaration",
-  "ClassDeclaration"
-]
 base.Statement = (node, st, c) => {
-  if (declarationTypes.includes(node.type)) {
+  if (
+    node.type === "VariableDeclaration" ||
+    node.type === "FunctionDeclaration" ||
+    node.type === "ClassDeclaration"
+  ) {
     c(node, st, "Declaration")
   } else {
     c(node, st)
@@ -380,7 +378,11 @@ base.MemberExpression = (node, st, c) => {
 }
 base.ModuleDeclaration = skipThrough
 base.ExportDefaultDeclaration = (node, st, c) => {
-  if (declarationTypes.includes(node.declaration.type)) {
+  if (
+    node.declaration.type === "VariableDeclaration" ||
+    node.declaration.type === "FunctionDeclaration" ||
+    node.declaration.type === "ClassDeclaration"
+  ) {
     c(node.declaration, st, "Declaration")
   } else {
     c(node.declaration, st, "Expression")

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -239,19 +239,25 @@ base.WhileStatement = base.DoWhileStatement = (node, st, c) => {
   c(node.body, st, "Statement")
 }
 base.ForStatement = (node, st, c) => {
-  if (node.init) c(node.init, st, "ForInit")
+  if (node.init) {
+    if (node.init.type == "VariableDeclaration")
+      c(node.init, st, "Statement")
+    else
+      c(node.init, st, "Expression")
+  }
   if (node.test) c(node.test, st, "Expression")
   if (node.update) c(node.update, st, "Expression")
   c(node.body, st, "Statement")
 }
 base.ForInStatement = base.ForOfStatement = (node, st, c) => {
-  c(node.left, st, "ForInit")
+  if (node.left) {
+    if (node.left.type == "VariableDeclaration")
+      c(node.left, st, "Statement")
+    else
+      c(node.left, st, "Pattern")
+  }
   c(node.right, st, "Expression")
   c(node.body, st, "Statement")
-}
-base.ForInit = (node, st, c) => {
-  if (node.type == "VariableDeclaration") c(node, st)
-  else c(node, st, "Expression")
 }
 base.DebuggerStatement = ignore
 

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -407,7 +407,6 @@ base.TaggedTemplateExpression = (node, st, c) => {
 }
 base.ClassDeclaration = base.ClassExpression = (node, st, c) => c(node, st, "Class")
 base.Class = (node, st, c) => {
-  if (node.id) c(node.id, st, "Pattern")
   if (node.superClass) c(node.superClass, st, "Expression")
   c(node.body, st, "ClassBody")
   if (node.decorators) {

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -180,7 +180,18 @@ base.BlockStatement = (node, st, c) => {
   for (let child of node.body)
     c(child, st, "Statement")
 }
-base.Statement = skipThrough
+const declarationTypes = [
+  "VariableDeclaration",
+  "FunctionDeclaration",
+  "ClassDeclaration"
+]
+base.Statement = (node, st, c) => {
+  if (declarationTypes.includes(node.type)) {
+    c(node, st, "Declaration")
+  } else {
+    c(node, st)
+  }
+}
 base.EmptyStatement = ignore
 base.ExpressionStatement = base.ParenthesizedExpression =
   (node, st, c) => c(node.expression, st, "Expression")
@@ -241,6 +252,7 @@ base.ForInit = (node, st, c) => {
 }
 base.DebuggerStatement = ignore
 
+base.Declaration = skipThrough
 base.FunctionDeclaration = (node, st, c) => c(node, st, "Function")
 base.VariableDeclaration = (node, st, c) => {
   for (let decl of node.declarations)
@@ -334,11 +346,15 @@ base.MemberExpression = (node, st, c) => {
 }
 base.ModuleDeclaration = skipThrough
 base.ExportDefaultDeclaration = (node, st, c) => {
-  c(node.declaration, st, node.declaration.id ? "Statement" : "Expression")
+  if (declarationTypes.includes(node.declaration.type)) {
+    c(node.declaration, st, "Declaration")
+  } else {
+    c(node.declaration, st, "Expression")
+  }
 }
 base.ExportNamedDeclaration = (node, st, c) => {
   if (node.declaration)
-    c(node.declaration, st, "Statement")
+    c(node.declaration, st, "Declaration")
   for (let spec of node.specifiers)
     c(spec, st, "ModuleSpecifier")
   if (node.source) c(node.source, st, "Expression")

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -296,7 +296,10 @@ base.ArrayPattern = (node, st, c) => {
 }
 base.ObjectPattern = (node, st, c) => {
   for (let prop of node.properties)
-    c(prop.value, st, "Property")
+    c(prop, st, "AssignmentProperty")
+}
+base.AssignmentProperty = (node, st, c) => {
+  c(node, st, "Property")
 }
 
 base.Expression = skipThrough

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -318,9 +318,12 @@ base.MemberExpression = (node, st, c) => {
   c(node.object, st, "Expression")
   if (node.computed) c(node.property, st, "Expression")
 }
-base.ExportNamedDeclaration = base.ExportDefaultDeclaration = (node, st, c) => {
+base.ExportDefaultDeclaration = (node, st, c) => {
+  c(node.declaration, st, node.declaration.id ? "Statement" : "Expression")
+}
+base.ExportNamedDeclaration = (node, st, c) => {
   if (node.declaration)
-    c(node.declaration, st, node.type == "ExportNamedDeclaration" || node.declaration.id ? "Statement" : "Expression")
+    c(node.declaration, st, "Statement")
   if (node.source) c(node.source, st, "Expression")
 }
 base.ExportAllDeclaration = (node, st, c) => {

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -331,7 +331,10 @@ base.ClassDeclaration = base.ClassExpression = (node, st, c) => c(node, st, "Cla
 base.Class = (node, st, c) => {
   if (node.id) c(node.id, st, "Pattern")
   if (node.superClass) c(node.superClass, st, "Expression")
-  for (let item of node.body.body)
+  c(node.body, st, "ClassBody")
+}
+base.ClassBody = (node, st, c) => {
+  for (let item of node.body)
     c(item, st)
 }
 base.MethodDefinition = base.Property = (node, st, c) => {

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -162,9 +162,23 @@ function ignore(_node, _st, _c) {}
 
 export const base = {}
 
-base.Program = base.BlockStatement = (node, st, c) => {
-  for (let stmt of node.body)
-    c(stmt, st, "Statement")
+const moduleDeclarationTypes = [
+  "ImportDeclaration",
+  "ExportNamedDeclaration",
+  "ExportDefaultDeclaration",
+  "ExportAllDeclaration"
+]
+base.Program = (node, st, c) => {
+  for (let child of node.body)
+    if (moduleDeclarationTypes.includes(child.type)) {
+      c(child, st, "ModuleDeclaration")
+    } else {
+      c(child, st, "Statement")
+    }
+}
+base.BlockStatement = (node, st, c) => {
+  for (let child of node.body)
+    c(child, st, "Statement")
 }
 base.Statement = skipThrough
 base.EmptyStatement = ignore
@@ -318,6 +332,7 @@ base.MemberExpression = (node, st, c) => {
   c(node.object, st, "Expression")
   if (node.computed) c(node.property, st, "Expression")
 }
+base.ModuleDeclaration = skipThrough
 base.ExportDefaultDeclaration = (node, st, c) => {
   c(node.declaration, st, node.declaration.id ? "Statement" : "Expression")
 }

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -346,9 +346,10 @@ base.ExportAllDeclaration = (node, st, c) => {
 }
 base.ImportDeclaration = (node, st, c) => {
   for (let spec of node.specifiers)
-    c(spec, st)
+    c(spec, st, "ModuleSpecifier")
   c(node.source, st, "Expression")
 }
+base.ModuleSpecifier = skipThrough
 base.ImportSpecifier = base.ImportDefaultSpecifier = base.ImportNamespaceSpecifier = base.Identifier = base.Literal = ignore
 
 base.TaggedTemplateExpression = (node, st, c) => {

--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -297,7 +297,13 @@ base.Expression = skipThrough
 base.ThisExpression = base.Super = base.MetaProperty = ignore
 base.ArrayExpression = (node, st, c) => {
   for (let elt of node.elements) {
-    if (elt) c(elt, st, "Expression")
+    if (elt) {
+      if (elt.type === "SpreadElement") {
+        c(elt, st)
+      } else {
+        c(elt, st, "Expression")
+      }
+    }
   }
 }
 base.ObjectExpression = (node, st, c) => {
@@ -335,7 +341,11 @@ base.NewExpression = (node, st, c) => {
   c(node.callee, st, "Expression")
   if (node.arguments)
     for (let arg of node.arguments)
-      c(arg, st, "Expression")
+      if (arg.type === "SpreadElement") {
+        c(arg, st)
+      } else {
+        c(arg, st, "Expression")
+      }
 }
 base.CallExpression = (node, st, c) => {
   if (node.callee.type === "Super") {
@@ -345,7 +355,11 @@ base.CallExpression = (node, st, c) => {
   }
   if (node.arguments)
     for (let arg of node.arguments)
-      c(arg, st, "Expression")
+      if (arg.type === "SpreadElement") {
+        c(arg, st)
+      } else {
+        c(arg, st, "Expression")
+      }
 }
 base.MemberExpression = (node, st, c) => {
   if (node.object.type === "Super") {


### PR DESCRIPTION
This fixes the walker to use the latest version of ESTree.

I went through the whole ESTree spec, including experimental features.

I added the following types: [`SwitchCase`](https://github.com/estree/estree/blob/master/es5.md#switchcase), [`ClassBody`](https://github.com/estree/estree/blob/master/es2015.md#classbody), [`Decorator`](https://github.com/estree/estree/blob/master/experimental/decorators.md)  (requires [`acorn-es7` plugin](https://github.com/angelozerr/acorn-es7)), [`TemplateElement`](https://github.com/estree/estree/blob/master/es2015.md#templateelement).

I added the following abstract types: [`Declaration`](https://github.com/estree/estree/blob/master/es5.md#declarations), [`ModuleSpecifier`](https://github.com/estree/estree/blob/master/es2015.md#modulespecifier), [`ModuleDeclaration`](https://github.com/estree/estree/blob/master/es2015.md#moduledeclaration), [`ExportSpecifier`](https://github.com/estree/estree/blob/master/es2015.md#exportspecifier), [`AssignmentProperty`](https://github.com/estree/estree/blob/master/es2015.md#objectpattern).

I fixed the following discrepancies with the spec:
  - [`SpreadElement`](https://github.com/estree/estree/blob/master/es2015.md#expressions) and [`Super`](https://github.com/estree/estree/blob/master/es2015.md#expressions) are not instances of `Expression`
  - [`Identifier`](https://github.com/estree/estree/blob/master/es5.md#identifier) and [`MemberExpression`](https://github.com/estree/estree/blob/master/es2015.md#expressions) are instances of `Expression`
  - [`ObjectPattern.properties`](https://github.com/estree/estree/blob/master/es2015.md#objectpattern) are instances of `Property` not `Pattern`
  - [`Class.id`](https://github.com/estree/estree/blob/master/es2015.md#classes) and [`Function.id`](https://github.com/estree/estree/blob/master/es5.md#functions) is an `Identifier` not a `Pattern`
  - [`ForOfStatement`](https://github.com/estree/estree/blob/master/es2015.md#forofstatement) and [`ForInStatement`](https://github.com/estree/estree/blob/master/es5.md#forinstatement) `left` can be a `Pattern` or a `VariableDeclaration`, not an `Expression`
  - [`AwaitExpression.argument`](https://github.com/estree/estree/blob/master/es2017.md#awaitexpression) is not optional
  - `VariablePattern` and `MemberPattern` do not exist