### PR TITLE
Implement B.3.5 (Closes #548)

### DIFF
--- a/src/lval.js
+++ b/src/lval.js
@@ -169,7 +169,7 @@ pp.parseMaybeDefault = function(startPos, startLoc, left) {
 // 'let' indicating that the lval creates a lexical ('let' or 'const') binding
 // 'none' indicating that the binding should be checked for illegal identifiers, but not for duplicate references
 
-pp.checkLVal = function(expr, bindingType, checkClashes) {
+pp.checkLVal = function(expr, bindingType, checkClashes, allowCatchParamNameRedeclaration) {
   switch (expr.type) {
   case "Identifier":
     if (this.strict && this.reservedWordsStrictBind.test(expr.name))
@@ -181,7 +181,7 @@ pp.checkLVal = function(expr, bindingType, checkClashes) {
     }
     if (bindingType && bindingType !== "none") {
       if (
-        bindingType === "var" && !this.canDeclareVarName(expr.name) ||
+        bindingType === "var" && !this.canDeclareVarName(expr.name, allowCatchParamNameRedeclaration) ||
         bindingType !== "var" && !this.canDeclareLexicalName(expr.name)
       ) {
         this.raiseRecoverable(expr.start, `Identifier '${expr.name}' has already been declared`)
@@ -200,30 +200,30 @@ pp.checkLVal = function(expr, bindingType, checkClashes) {
 
   case "ObjectPattern":
     for (let prop of expr.properties)
-      this.checkLVal(prop, bindingType, checkClashes)
+      this.checkLVal(prop, bindingType, checkClashes, allowCatchParamNameRedeclaration)
     break
 
   case "Property":
     // AssignmentProperty has type == "Property"
-    this.checkLVal(expr.value, bindingType, checkClashes)
+    this.checkLVal(expr.value, bindingType, checkClashes, allowCatchParamNameRedeclaration)
     break
 
   case "ArrayPattern":
     for (let elem of expr.elements) {
-      if (elem) this.checkLVal(elem, bindingType, checkClashes)
+      if (elem) this.checkLVal(elem, bindingType, checkClashes, allowCatchParamNameRedeclaration)
     }
     break
 
   case "AssignmentPattern":
-    this.checkLVal(expr.left, bindingType, checkClashes)
+    this.checkLVal(expr.left, bindingType, checkClashes, allowCatchParamNameRedeclaration)
     break
 
   case "RestElement":
-    this.checkLVal(expr.argument, bindingType, checkClashes)
+    this.checkLVal(expr.argument, bindingType, checkClashes, allowCatchParamNameRedeclaration)
     break
 
   case "ParenthesizedExpression":
-    this.checkLVal(expr.expression, bindingType, checkClashes)
+    this.checkLVal(expr.expression, bindingType, checkClashes, allowCatchParamNameRedeclaration)
     break
 
   default:

--- a/src/statement.js
+++ b/src/statement.js
@@ -309,7 +309,10 @@ pp.parseTryStatement = function(node) {
     this.expect(tt.parenL)
     clause.param = this.parseBindingAtom()
     this.enterLexicalScope()
-    this.checkLVal(clause.param, "let")
+    if (clause.param.type == "Identifier") {
+      this.checkLVal(clause.param, "none")
+      this.declareCatchParamName(clause.param.name)
+    } else this.checkLVal(clause.param, "let")
     this.expect(tt.parenR)
     clause.body = this.parseBlock(false)
     this.exitLexicalScope()
@@ -440,7 +443,7 @@ pp.parseVar = function(node, isFor, kind) {
   node.kind = kind
   for (;;) {
     let decl = this.startNode()
-    this.parseVarId(decl, kind)
+    this.parseVarId(decl, kind, isFor)
     if (this.eat(tt.eq)) {
       decl.init = this.parseMaybeAssign(isFor)
     } else if (kind === "const" && !(this.type === tt._in || (this.options.ecmaVersion >= 6 && this.isContextual("of")))) {
@@ -456,9 +459,9 @@ pp.parseVar = function(node, isFor, kind) {
   return node
 }
 
-pp.parseVarId = function(decl, kind) {
+pp.parseVarId = function(decl, kind, isFor) {
   decl.id = this.parseBindingAtom(kind)
-  this.checkLVal(decl.id, kind, false)
+  this.checkLVal(decl.id, kind, false, !(isFor && (this.options.ecmaVersion >= 6 && this.isContextual("of"))))
 }
 
 // Parse a function declaration or literal (depending on the
@@ -474,7 +477,7 @@ pp.parseFunction = function(node, isStatement, allowExpressionBody, isAsync) {
   if (isStatement) {
     node.id = isStatement === "nullableID" && this.type != tt.name ? null : this.parseIdent()
     if (node.id) {
-      this.checkLVal(node.id, "var")
+      this.checkLVal(node.id, "var", false, true)
     }
   }
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -29318,22 +29318,29 @@ test("((b), a=1)", {})
 
 test("(x) = 1", {})
 
-testFail("try {} catch (foo) { var foo; }", "Identifier 'foo' has already been declared (1:25)")
+test("try {} catch (foo) { var foo; }", {})
 testFail("try {} catch (foo) { let foo; }", "Identifier 'foo' has already been declared (1:25)", {ecmaVersion: 6})
-testFail("try {} catch (foo) { try {} catch (_) { var foo; } }", "Identifier 'foo' has already been declared (1:44)")
+test("try {} catch (foo) { try {} catch (_) { var foo; } }", {})
 testFail("try {} catch ([foo]) { var foo; }", "Identifier 'foo' has already been declared (1:27)", {ecmaVersion: 6})
 testFail("try {} catch ({ foo }) { var foo; }", "Identifier 'foo' has already been declared (1:29)", {ecmaVersion: 6})
 testFail("try {} catch ([foo, foo]) {}", "Identifier 'foo' has already been declared (1:20)", {ecmaVersion: 6})
 testFail("try {} catch ({ a: foo, b: { c: [foo] } }) {}", "Identifier 'foo' has already been declared (1:33)", {ecmaVersion: 6})
 testFail("let foo; try {} catch (foo) {} let foo;", "Identifier 'foo' has already been declared (1:35)", {ecmaVersion: 6})
-testFail("try {} catch (foo) { function foo() {} }", "Identifier 'foo' has already been declared (1:30)")
+test("try {} catch (foo) { function foo() {} }", {})
 
 test("try {} catch (foo) {} var foo;", {})
 test("try {} catch (foo) {} let foo;", {}, {ecmaVersion: 6})
 test("try {} catch (foo) { { let foo; } }", {}, {ecmaVersion: 6})
 test("try {} catch (foo) { function x() { var foo; } }", {}, {ecmaVersion: 6})
 test("try {} catch (foo) { function x(foo) {} }", {}, {ecmaVersion: 6})
+test("try {} catch (a) { if(1) function a(){} }", {})
 
+test("try {} catch (foo) { for (var foo = 1;;); }", {})
+test("try {} catch (foo) { for (var foo in bar); }", {})
+test("try {} catch (foo) { for (var [foo] in bar); }", {}, {ecmaVersion: 6})
+testFail("try {} catch ([a, a]) {}", "Identifier 'a' has already been declared (1:18)", {ecmaVersion: 6})
+
+testFail("try {} catch (foo) { for (var foo of bar); }", "Identifier 'foo' has already been declared (1:30)", {ecmaVersion: 6})
 test("'use strict'; let foo = function foo() {}", {}, {ecmaVersion: 6})
 
 test("/**/ --> comment\n", {})


### PR DESCRIPTION
Spec: [B.3.5](https://tc39.github.io/ecma262/#sec-variablestatements-in-catch-blocks)

I'm not sure I actually got the semantics right, test262 unfortunately doesn't include any specific negative tests for B.3.5.

There's definitely a problem with function declarations in the catch block, but that's present in current trunk as well. As far as I understand it, function declarations should be handled as lexical bindings, but [B.3.3.1](https://tc39.github.io/ecma262/#sec-web-compat-functiondeclarationinstantiation) allows them to re-declare each other (as in `if (a) function f() {} else function f() {}`). Currently, they are handled as `var` bindings, which makes them behave wrongly in `catch` blocks.