### PR TITLE
Consider Template Literal also as expression

### DIFF
--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -355,7 +355,7 @@ base.ImportSpecifier = base.ImportDefaultSpecifier = base.ImportNamespaceSpecifi
 
 base.TaggedTemplateExpression = (node, st, c) => {
   c(node.tag, st, "Expression")
-  c(node.quasi, st)
+  c(node.quasi, st, "Expression")
 }
 base.ClassDeclaration = base.ClassExpression = (node, st, c) => c(node, st, "Class")
 base.Class = (node, st, c) => {


### PR DESCRIPTION
The **TemplateLiteral** should also be considered as expression as per [here](https://github.com/estree/estree/blob/master/es2015.md#template-literals)