### PR TITLE
Fix node.end position comparison in `walk.findNodeAround(…)`

### DIFF
--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -122,7 +122,7 @@ export function findNodeAround(node, pos, test, base, state) {
   try {
     (function c(node, st, override) {
       let type = override || node.type
-      if (node.start > pos || node.end < pos) return
+      if (node.start > pos || node.end <= pos) return
       base[type](node, st, c)
       if (test(type, node)) throw new Found(node, st)
     })(node, state)


### PR DESCRIPTION
Hi there! I think I tracked down a bug in the `walk.findNodeAround()` function. I couldn't see any tests for the walker functions in the codebase and didn't know how best to add it so I've included a reduced test case in the PR.

### Why I believe this is a bug

According to the [AST spec](https://developer.mozilla.org/en-US/docs/Mozilla/Projects/SpiderMonkey/Parser_API#Node_objects), `node.end` is "the position of the first character _after_ the parsed source region". Therefore, for a node to be considered "around" a given position, its `.end` property must not be equal to the given position.

The wording of the function "around" can be ambiguous, but the comment here clarifies that the returned node should "contain" the provided `pos` (not simply to be adjacent or nearby, as a more flexible definition of "around" would allow)…
https://github.com/acornjs/acorn/blob/4d1230699be387e31250735cf43f0723ac747007/src/walk/index.js#L117-L119

### Steps to reproduce

The following script contains some assertions which, according the the comment, should both pass. However, as you will see if you run it the latter assertion throws.

_Save the following `walk.js` and run `node walk`._

```js
const acorn = require('acorn')
const walk = require('acorn/dist/walk')
const fs = require('fs')
const assert = require('assert')

const js = `var e = 123;foo();`
//                      ^^
//                      ││
//             pos 12 <─┘└─> pos 13

const ast = acorn.parse(js)

const foundA = walk.findNodeAround(ast, 13, 'Statement')
console.log('Found "Statement" node around pos 13', {
  start: foundA.node.start,
  end: foundA.node.end
})
assert(
  foundA.node.end > 13,
  'the "end" of the node should be greater than the given "pos" value'
)

const foundB = walk.findNodeAround(ast, 12, 'Statement')
console.log(foundB)
console.log('Found "Statement" node around pos 12', {
  start: foundB.node.start,
  end: foundB.node.end
})
assert(
  foundB.node.end > 12,
  'the "end" of the node should be greater than the given "pos" value'
)
```


### Analysis

This bug manifests when:

- there are two adjacent nodes for which the `test` function returns `true`
- there is no whitespace separating these two nodes
- the `pos` value is the `start` value of the latter node _and_ the `end` value of the preceding node

If all these conditions are met, the function will incorrectly return the preceding node when it should return the latter.

The fix is to simply disallow a node when its `end` is __equal to__ or less than `pos`.