### PR TITLE
Fix misleading error message for octal escapes in template strings

### DIFF
--- a/src/tokenize.js
+++ b/src/tokenize.js
@@ -628,7 +628,12 @@ pp.readEscapedChar = function(inTemplate) {
       this.pos += octalStr.length - 1
       ch = this.input.charCodeAt(this.pos)
       if ((octalStr !== "0" || ch == 56 || ch == 57) && (this.strict || inTemplate)) {
-        this.invalidStringToken(this.pos - 1 - octalStr.length, "Octal literal in strict mode")
+        this.invalidStringToken(
+          this.pos - 1 - octalStr.length,
+          inTemplate
+            ? "Octal literal in template string"
+            : "Octal literal in strict mode"
+        )
       }
       return String.fromCharCode(octal)
     }

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -13281,7 +13281,7 @@ testFail("[...a, b] = c", "Comma is not permitted after the rest element (1:5)",
 
 testFail("({ t(eval) { \"use strict\"; } });", "Binding eval in strict mode (1:5)", {ecmaVersion: 6});
 
-testFail("\"use strict\"; `${test}\\02`;", "Octal literal in strict mode (1:22)", {ecmaVersion: 6});
+testFail("\"use strict\"; `${test}\\02`;", "Octal literal in template string (1:22)", {ecmaVersion: 6});
 
 testFail("if (1) import \"acorn\";", "'import' and 'export' may only appear at the top level (1:7)", {ecmaVersion: 6});
 
@@ -14591,7 +14591,9 @@ test("export default function foo() {} false", {
 
 // https://github.com/acornjs/acorn/issues/274
 
-testFail("`\\07`", "Octal literal in strict mode (1:1)", {ecmaVersion: 6});
+testFail("`\\07`", "Octal literal in template string (1:1)", {ecmaVersion: 6});
+
+testFail("(function(){ 'use strict'; '\\07'; })", "Octal literal in strict mode (1:28)", {ecmaVersion: 6});
 
 // https://github.com/acornjs/acorn/issues/277
 


### PR DESCRIPTION
When parsing code like this:

```js
`\033`;
```

Acorn produces the following error message:

```
SyntaxError: Octal literal in strict mode (1:1)
```

This error message is a bit misleading because the code is not in strict mode. It's correct to report an error here, but the error is actually because the octal escape sequence is in a template literal.

This commit updates the error message to include something about template strings, rather than claiming that the error is due to strict mode.