### PR TITLE
Fix RestElement in function object parameters causing walk to fail

### DIFF
--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -285,7 +285,7 @@ base.ArrayPattern = (node, st, c) => {
 base.ObjectPattern = (node, st, c) => {
   for (let prop of node.properties) {
     if (prop.computed) c(prop.key, st, "Expression")
-    c(prop.value, st, "Pattern")
+    if (prop.value) c(prop.value, st, "Pattern")
   }
 }
 


### PR DESCRIPTION
Destructuring a function parameter object with a RestElement causes an uncaught error when the tree is walked using walk.simple().

To reproduce, use the following program body:

> class Test {
>   failMethod({a, ...args}) {
>     // Anything
>   }
> }

Calling walk.simple() on this fails because (see the attached commit) the ObjectPattern default handler does not check for the existence of prop.value before using it as a node.