### PR TITLE
Fix walking binding-less `catch {}`

### DIFF
--- a/src/walk/index.js
+++ b/src/walk/index.js
@@ -229,7 +229,7 @@ base.TryStatement = (node, st, c) => {
   if (node.finalizer) c(node.finalizer, st, "Statement")
 }
 base.CatchClause = (node, st, c) => {
-  c(node.param, st, "Pattern")
+  if (node.param) c(node.param, st, "Pattern")
   c(node.body, st, "ScopeBody")
 }
 base.WhileStatement = base.DoWhileStatement = (node, st, c) => {


### PR DESCRIPTION
As of https://github.com/acornjs/acorn/commit/a19c69aa004814b187dcbaecfa9f72737e35f33a, the `.param` property of a CatchClause node can be null.