### PR TITLE
Backwards compatibility

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -4,7 +4,7 @@ import {SourceLocation} from "./locutil"
 export class Node {
   constructor(parser, pos, loc) {
     this.type = ""
-    this.start = pos
+    this.start = pos || 0;
     this.end = 0
     if (parser) {
       if (parser.options.locations)

--- a/src/node.js
+++ b/src/node.js
@@ -6,12 +6,14 @@ export class Node {
     this.type = ""
     this.start = pos
     this.end = 0
-    if (parser.options.locations)
-      this.loc = new SourceLocation(parser, loc)
-    if (parser.options.directSourceFile)
-      this.sourceFile = parser.options.directSourceFile
-    if (parser.options.ranges)
-      this.range = [pos, 0]
+    if (parser) {
+      if (parser.options.locations)
+        this.loc = new SourceLocation(parser, loc)
+      if (parser.options.directSourceFile)
+        this.sourceFile = parser.options.directSourceFile
+      if (parser.options.ranges)
+        this.range = [pos, 0]
+    }
   }
 }
 


### PR DESCRIPTION
Old `node_t` construtctor don't needed a `parser` argument. Now libraries using old Acorn versions can't update to new Acorn versions without forcing an `{options:{}}` object as the first argument, or an Exception will happen.