### PR TITLE
fix(typings): Add `allowAwaitOutsideFunction` to the Options interface

### DIFF
--- a/acorn/dist/acorn.d.ts
+++ b/acorn/dist/acorn.d.ts
@@ -19,6 +19,7 @@ declare namespace acorn {
     allowReserved?: boolean
     allowReturnOutsideFunction?: boolean
     allowImportExportEverywhere?: boolean
+    allowAwaitOutsideFunction?: boolean
     allowHashBang?: boolean
     locations?: boolean
     onToken?: ((token: Token) => any) | Token[]


### PR DESCRIPTION
Defined at https://github.com/acornjs/acorn/blob/a0f0c73ec11fd041e8a4626d02146d2e5b22f8f5/acorn/src/options.js#L38-L40