### PR TITLE
Remove unused argument to parseBindingAtom()

### DIFF
--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -479,7 +479,7 @@ pp.parseVar = function(node, isFor, kind) {
 }
 
 pp.parseVarId = function(decl, kind) {
-  decl.id = this.parseBindingAtom(kind)
+  decl.id = this.parseBindingAtom()
   this.checkLVal(decl.id, kind === "var" ? BIND_VAR : BIND_LEXICAL, false)
 }
 


### PR DESCRIPTION
parseBindingAtom does not have any arguments afaics