### PR TITLE
Quote the error-causing text in parse errors

### DIFF
--- a/acorn/src/location.js
+++ b/acorn/src/location.js
@@ -12,6 +12,12 @@ const pp = Parser.prototype
 pp.raise = function(pos, message) {
   let loc = getLineInfo(this.input, pos)
   message += " (" + loc.line + ":" + loc.column + ")"
+  let lines = this.input.split('\n')
+  message = message + '\n' + lines[loc.line - 1] + '\n';
+  for (var i = 0; i < loc.column; i++) {
+    message += ' '
+  }
+  message += '^\n'
   let err = new SyntaxError(message)
   err.pos = pos; err.loc = loc; err.raisedAt = this.pos
   throw err


### PR DESCRIPTION
This makes parse errors look like this:
```
SyntaxError: Unexpected token (1433:40)
var ASM_CONSTS = [function() { var x = !<->5.; }];
                                         ^
```
That is, it adds a line that quotes the text with the error, and a line under it with `^` to point directly at the error.