### PR TITLE
Fix a small error in an example of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ avoid needlessly confusing the JavaScript engine's optimizer.
 const {Parser} = require("acorn")
 
 const MyParser = Parser.extend(
-  require("acorn-jsx"),
+  require("acorn-jsx")(),
   require("acorn-bigint")
 )
 console.log(MyParser.parse("// Some bigint + JSX code"))


### PR DESCRIPTION
According to the [acorn-jsx](https://github.com/RReverser/acorn-jsx) documentation, the module returns a function that must be called when extending the parser. :)