### PR TITLE
Correctly check for-in and for-of loop for invalid left-hand side

### DIFF
--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -451,7 +451,12 @@ pp.parseForIn = function(node, init) {
   if (
     init.type === "VariableDeclaration" &&
     init.declarations[0].init != null &&
-    (!isForIn || this.strict || init.kind !== "var" || init.declarations[0].id.type !== "Identifier")
+    (
+      this.options.ecmaVersion < 8 ||
+      this.strict ||
+      init.kind !== "var" ||
+      init.declarations[0].id.type !== "Identifier"
+    )
   ) {
     this.raise(
       init.start,

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -215,8 +215,7 @@ pp.parseForStatement = function(node) {
     this.next()
     this.parseVar(init, true, kind)
     this.finishNode(init, "VariableDeclaration")
-    if ((this.type === tt._in || (this.options.ecmaVersion >= 6 && this.isContextual("of"))) && init.declarations.length === 1 &&
-        !(kind !== "var" && init.declarations[0].init)) {
+    if ((this.type === tt._in || (this.options.ecmaVersion >= 6 && this.isContextual("of"))) && init.declarations.length === 1) {
       if (this.options.ecmaVersion >= 9) {
         if (this.type === tt._in) {
           if (awaitAt > -1) this.unexpected(awaitAt)
@@ -446,21 +445,30 @@ pp.parseFor = function(node, init) {
 // same from parser's perspective.
 
 pp.parseForIn = function(node, init) {
-  let type = this.type === tt._in ? "ForInStatement" : "ForOfStatement"
+  const isForIn = this.type === tt._in
   this.next()
-  if (type === "ForInStatement") {
-    if (init.type === "AssignmentPattern" ||
-      (init.type === "VariableDeclaration" && init.declarations[0].init != null &&
-       (this.strict || init.declarations[0].id.type !== "Identifier")))
-      this.raise(init.start, "Invalid assignment in for-in loop head")
+
+  if (
+    init.type === "VariableDeclaration" &&
+    init.declarations[0].init != null &&
+    (!isForIn || this.strict || init.kind !== "var" || init.declarations[0].id.type !== "Identifier")
+  ) {
+    this.raise(
+      init.start,
+      `${
+        isForIn ? "for-in" : "for-of"
+      } loop variable declaration may not have an initializer`
+    )
+  } else if (init.type === "AssignmentPattern") {
+    this.raise(init.start, "Invalid left-hand side in for-loop")
   }
   node.left = init
-  node.right = type === "ForInStatement" ? this.parseExpression() : this.parseMaybeAssign()
+  node.right = isForIn ? this.parseExpression() : this.parseMaybeAssign()
   this.expect(tt.parenR)
   node.body = this.parseStatement("for")
   this.exitScope()
   this.labels.pop()
-  return this.finishNode(node, type)
+  return this.finishNode(node, isForIn ? "ForInStatement" : "ForOfStatement")
 }
 
 // Parse a list of variable declarations.

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -6028,95 +6028,6 @@ test("for (var x of list) process(x);", {
   locations: true
 });
 
-test("for (var x = 42 of list) process(x);", {
-  type: "Program",
-  body: [{
-    type: "ForOfStatement",
-    left: {
-      type: "VariableDeclaration",
-      declarations: [{
-        type: "VariableDeclarator",
-        id: {
-          type: "Identifier",
-          name: "x",
-          loc: {
-            start: {line: 1, column: 9},
-            end: {line: 1, column: 10}
-          }
-        },
-        init: {
-          type: "Literal",
-          value: 42,
-          raw: "42",
-          loc: {
-            start: {line: 1, column: 13},
-            end: {line: 1, column: 15}
-          }
-        },
-        loc: {
-          start: {line: 1, column: 9},
-          end: {line: 1, column: 15}
-        }
-      }],
-      kind: "var",
-      loc: {
-        start: {line: 1, column: 5},
-        end: {line: 1, column: 15}
-      }
-    },
-    right: {
-      type: "Identifier",
-      name: "list",
-      loc: {
-        start: {line: 1, column: 19},
-        end: {line: 1, column: 23}
-      }
-    },
-    body: {
-      type: "ExpressionStatement",
-      expression: {
-        type: "CallExpression",
-        callee: {
-          type: "Identifier",
-          name: "process",
-          loc: {
-            start: {line: 1, column: 25},
-            end: {line: 1, column: 32}
-          }
-        },
-        arguments: [{
-          type: "Identifier",
-          name: "x",
-          loc: {
-            start: {line: 1, column: 33},
-            end: {line: 1, column: 34}
-          }
-        }],
-        loc: {
-          start: {line: 1, column: 25},
-          end: {line: 1, column: 35}
-        }
-      },
-      loc: {
-        start: {line: 1, column: 25},
-        end: {line: 1, column: 36}
-      }
-    },
-    loc: {
-      start: {line: 1, column: 0},
-      end: {line: 1, column: 36}
-    }
-  }],
-  loc: {
-    start: {line: 1, column: 0},
-    end: {line: 1, column: 36}
-  }
-}, {
-  ecmaVersion: 6,
-  ranges: true,
-  locations: true
-});
-
 test("for (let x of list) process(x);", {
   type: "Program",
   body: [{
@@ -13204,9 +13115,15 @@ testFail("\"use strict\"; ({ v: eval } = obj)", "Assigning to eval in strict mod
 
 testFail("\"use strict\"; ({ v: arguments } = obj)", "Assigning to arguments in strict mode (1:20)", {ecmaVersion: 6});
 
-testFail("for (let x = 42 in list) process(x);", "Unexpected token (1:16)", {ecmaVersion: 6});
+testFail("for (let x = 42 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
+testFail("for (const x = 42 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
 
-testFail("for (let x = 42 of list) process(x);", "Unexpected token (1:16)", {ecmaVersion: 6});
+testFail("for (let x = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
+testFail("for (const x = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
+testFail("for (var x = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
+testFail("for (var {x} = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
+testFail("for (var [x] = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
+testFail("var x; for (x = 42 of list) process(x);", "Invalid left-hand side in for-loop (1:12)", {ecmaVersion: 6});
 
 testFail("import foo", "Unexpected token (1:10)", {ecmaVersion: 6, sourceType: "module"});
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -19689,9 +19689,10 @@ test("for (var x in list) process(x);", {
     }
   }
 });
-testFail("var x; for (x = 0 in list) process(x);", "Invalid assignment in for-in loop head (1:12)", { ecmaVersion: 6 })
-testFail("'use strict'; for (var x = 0 in list) process(x);", "Invalid assignment in for-in loop head (1:19)")
-testFail("for (var [x] = 0 in list) process(x);", "Invalid assignment in for-in loop head (1:5)", { ecmaVersion: 6 })
+testFail("var x; for (x = 0 in list) process(x);", "Invalid left-hand side in for-loop (1:12)", { ecmaVersion: 6 })
+testFail("'use strict'; for (var x = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:19)")
+testFail("for (var [x] = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
+testFail("for (var {x} = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
 
 test("for (var x = 42 in list) process(x);", {
   type: "Program",

--- a/test/tests.js
+++ b/test/tests.js
@@ -19693,6 +19693,7 @@ testFail("var x; for (x = 0 in list) process(x);", "Invalid left-hand side in fo
 testFail("'use strict'; for (var x = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:19)")
 testFail("for (var [x] = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
 testFail("for (var {x} = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
+testFail("for (var x = 42 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
 
 test("for (var x = 42 in list) process(x);", {
   type: "Program",
@@ -19848,7 +19849,7 @@ test("for (var x = 42 in list) process(x);", {
       column: 36
     }
   }
-});
+}, { ecmaVersion: 8, locations: true });
 
 test("for (var i = function() { return 10 in [] } in list) process(x);", {
   type: "Program",
@@ -20075,7 +20076,7 @@ test("for (var i = function() { return 10 in [] } in list) process(x);", {
       column: 64
     }
   }
-});
+}, { ecmaVersion: 8, locations: true });
 
 test("while (true) { continue; }", {
   type: "Program",


### PR DESCRIPTION
I noticed that acorn parses `for (var x = 42 of list) process(x);` correctly although it should not because the spec only makes an exception for for-in https://www.ecma-international.org/ecma-262/9.0/index.html#sec-initializers-in-forin-statement-heads

I refactored the way the detection for invalid left-hand side is detected so that there are nicer error messages. The messages are copied from chrome/v8.