### PR TITLE
Correctly disallow var declarations with init in for-of loops

### DIFF
--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -452,6 +452,7 @@ pp.parseForIn = function(node, init) {
     init.type === "VariableDeclaration" &&
     init.declarations[0].init != null &&
     (
+      !isForIn ||
       this.options.ecmaVersion < 8 ||
       this.strict ||
       init.kind !== "var" ||

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -13121,6 +13121,7 @@ testFail("for (const x = 42 in list) process(x);", "for-in loop variable declara
 testFail("for (let x = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
 testFail("for (const x = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
 testFail("for (var x = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
+testFail("for (var x = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 8});
 testFail("for (var {x} = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
 testFail("for (var [x] = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
 testFail("var x; for (x = 42 of list) process(x);", "Invalid left-hand side in for-loop (1:12)", {ecmaVersion: 6});


### PR DESCRIPTION
I'm sorry I made a mistake. When I added the ecmaVersion check I by accident removed the check for the `for-of` loop. 

So it was allowing `for (var x = 42 of list) process(x);` if ecmaVersion >= 8, which was the whole point of the other PR to disallow. :D

Now it is correct.

Sorry