### PR TITLE
Add dynamic import

### DIFF
--- a/acorn-loose/src/expression.js
+++ b/acorn-loose/src/expression.js
@@ -295,9 +295,22 @@ lp.parseExprAtom = function() {
   case tt.backQuote:
     return this.parseTemplate()
 
+  case tt._import:
+    if (this.options.ecmaVersion > 10) {
+      return this.parseDynamicImport()
+    } else {
+      return this.dummyIdent()
+    }
+
   default:
     return this.dummyIdent()
   }
+}
+
+lp.parseDynamicImport = function() {
+  const node = this.startNode()
+  this.next()
+  return this.finishNode(node, "Import")
 }
 
 lp.parseNew = function() {

--- a/acorn-loose/src/statement.js
+++ b/acorn-loose/src/statement.js
@@ -178,6 +178,12 @@ lp.parseStatement = function() {
     return this.parseClass(true)
 
   case tt._import:
+    if (this.options.ecmaVersion > 10 && this.lookAhead(1).type === tt.parenL) {
+      node.expression = this.parseExpression()
+      this.semicolon()
+      return this.finishNode(node, "ExpressionStatement")
+    }
+
     return this.parseImport()
 
   case tt._export:

--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -281,7 +281,7 @@ pp.parseSubscript = function(base, startPos, startLoc, noCalls, maybeAsyncArrow)
     this.yieldPos = 0
     this.awaitPos = 0
     this.awaitIdentPos = 0
-    let exprList = this.parseExprList(tt.parenR, this.options.ecmaVersion >= 8, false, refDestructuringErrors)
+    let exprList = this.parseExprList(tt.parenR, this.options.ecmaVersion >= 8 && base.type !== "Import", false, refDestructuringErrors)
     if (maybeAsyncArrow && !this.canInsertSemicolon() && this.eat(tt.arrow)) {
       this.checkPatternErrors(refDestructuringErrors, false)
       this.checkYieldAwaitInDefaultParams()
@@ -299,6 +299,16 @@ pp.parseSubscript = function(base, startPos, startLoc, noCalls, maybeAsyncArrow)
     let node = this.startNodeAt(startPos, startLoc)
     node.callee = base
     node.arguments = exprList
+    if (node.callee.type === "Import") {
+      if (node.arguments.length !== 1) {
+        this.raise(node.start, "import() requires exactly one argument")
+      }
+
+      const importArg = node.arguments[0]
+      if (importArg && importArg.type === "SpreadElement") {
+        this.raise(importArg.start, "... is not allowed in import()")
+      }
+    }
     base = this.finishNode(node, "CallExpression")
   } else if (this.type === tt.backQuote) {
     let node = this.startNodeAt(startPos, startLoc)
@@ -538,7 +548,10 @@ pp.parseNew = function() {
   }
   let startPos = this.start, startLoc = this.startLoc
   node.callee = this.parseSubscripts(this.parseExprAtom(), startPos, startLoc, true)
-  if (this.eat(tt.parenL)) node.arguments = this.parseExprList(tt.parenR, this.options.ecmaVersion >= 8, false)
+  if (this.options.ecmaVersion > 10 && node.callee.type === "Import") {
+    this.raise(node.callee.start, "Cannot use new with import(...)")
+  }
+  if (this.eat(tt.parenL)) node.arguments = this.parseExprList(tt.parenR, this.options.ecmaVersion >= 8 && node.callee.type !== "Import", false)
   else node.arguments = empty
   return this.finishNode(node, "NewExpression")
 }

--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -409,9 +409,25 @@ pp.parseExprAtom = function(refDestructuringErrors) {
   case tt.backQuote:
     return this.parseTemplate()
 
+  case tt._import:
+    if (this.options.ecmaVersion > 10) {
+      return this.parseDynamicImport()
+    } else {
+      return this.unexpected()
+    }
+
   default:
     this.unexpected()
   }
+}
+
+pp.parseDynamicImport = function() {
+  const node = this.startNode()
+  this.next()
+  if (this.type !== tt.parenL) {
+    this.unexpected()
+  }
+  return this.finishNode(node, "Import")
 }
 
 pp.parseLiteral = function(value) {

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -120,6 +120,14 @@ pp.parseStatement = function(context, topLevel, exports) {
   case tt.semi: return this.parseEmptyStatement(node)
   case tt._export:
   case tt._import:
+    if (this.options.ecmaVersion > 10 && starttype === tt._import) {
+      skipWhiteSpace.lastIndex = this.pos
+      let skip = skipWhiteSpace.exec(this.input)
+      let next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next)
+      if (nextCh === 40) // '('
+        return this.parseExpressionStatement(node, this.parseExpression())
+    }
+
     if (!this.options.allowImportExportEverywhere) {
       if (!topLevel)
         this.raise(this.start, "'import' and 'export' may only appear at the top level")

--- a/acorn/src/tokentype.js
+++ b/acorn/src/tokentype.js
@@ -136,7 +136,7 @@ export const types = {
   _class: kw("class", startsExpr),
   _extends: kw("extends", beforeExpr),
   _export: kw("export"),
-  _import: kw("import"),
+  _import: kw("import", startsExpr),
   _null: kw("null", startsExpr),
   _true: kw("true", startsExpr),
   _false: kw("false", startsExpr),

--- a/bin/run_test262.js
+++ b/bin/run_test262.js
@@ -11,14 +11,13 @@ const unsupportedFeatures = [
   "class-static-fields-private",
   "class-static-fields-public",
   "class-static-methods-private",
-  "dynamic-import",
   "export-star-as-namespace-from-module",
   "import.meta",
   "numeric-separator-literal"
 ];
 
 run(
-  (content, {sourceType}) => parse(content, {sourceType, ecmaVersion: 10, allowHashBang: true}),
+  (content, {sourceType}) => parse(content, {sourceType, ecmaVersion: 11, allowHashBang: true}),
   {
     testsDirectory: path.dirname(require.resolve("test262/package.json")),
     skip: test => (test.attrs.features && unsupportedFeatures.some(f => test.attrs.features.includes(f))),

--- a/test/run.js
+++ b/test/run.js
@@ -14,6 +14,7 @@
   require("./tests-regexp-2018.js");
   require("./tests-json-superset.js");
   require("./tests-optional-catch-binding.js");
+  require("./tests-dynamic-import.js");
   var acorn = require("../acorn")
   var acorn_loose = require("../acorn-loose")
 

--- a/test/tests-dynamic-import.js
+++ b/test/tests-dynamic-import.js
@@ -1,0 +1,95 @@
+// Tests for ECMAScript 2020 dynaimic import
+
+if (typeof exports != 'undefined') {
+  var test = require('./driver.js').test;
+  var testFail = require('./driver.js').testFail;
+}
+
+test(
+  "import('dynamicImport.js')",
+  {
+    type: 'Program',
+    start: 0,
+    end: 26,
+    body: [
+      {
+        type: 'ExpressionStatement',
+        start: 0,
+        end: 26,
+        expression: {
+          type: 'CallExpression',
+          start: 0,
+          end: 26,
+          callee: { type: 'Import', start: 0, end: 6 },
+          arguments: [
+            {
+              type: 'Literal',
+              start: 7,
+              end: 25,
+              value: 'dynamicImport.js',
+              raw: "'dynamicImport.js'"
+            }
+          ]
+        }
+      }
+    ],
+    sourceType: 'script'
+  },
+  { ecmaVersion: 11 }
+);
+
+test(
+  "function* a() { yield import('http'); }",
+  {
+    type: 'Program',
+    start: 0,
+    end: 39,
+    body: [
+      {
+        type: 'FunctionDeclaration',
+        start: 0,
+        end: 39,
+        id: { type: 'Identifier', start: 10, end: 11, name: 'a' },
+        expression: false,
+        generator: true,
+        async: false,
+        params: [],
+        body: {
+          type: 'BlockStatement',
+          start: 14,
+          end: 39,
+          body: [
+            {
+              type: 'ExpressionStatement',
+              start: 16,
+              end: 37,
+              expression: {
+                type: 'YieldExpression',
+                start: 16,
+                end: 36,
+                delegate: false,
+                argument: {
+                  type: 'CallExpression',
+                  start: 22,
+                  end: 36,
+                  callee: { type: 'Import', start: 22, end: 28 },
+                  arguments: [{ type: 'Literal', start: 29, end: 35, value: 'http', raw: "'http'" }]
+                }
+              }
+            }
+          ]
+        }
+      }
+    ],
+    sourceType: 'script'
+  },
+  { ecmaVersion: 11 }
+);
+
+testFail('function failsParse() { return import.then(); }', 'Unexpected token (1:37)', {
+  ecmaVersion: 11
+});
+
+testFail("var dynImport = import; dynImport('http');", 'Unexpected token (1:22)', {
+  ecmaVersion: 11
+});

--- a/test/tests-dynamic-import.js
+++ b/test/tests-dynamic-import.js
@@ -1,4 +1,4 @@
-// Tests for ECMAScript 2020 dynaimic import
+// Tests for ECMAScript 2020 dynamic import
 
 if (typeof exports != 'undefined') {
   var test = require('./driver.js').test;
@@ -87,9 +87,42 @@ test(
 );
 
 testFail('function failsParse() { return import.then(); }', 'Unexpected token (1:37)', {
-  ecmaVersion: 11
+  ecmaVersion: 11,
+  loose: false
 });
 
 testFail("var dynImport = import; dynImport('http');", 'Unexpected token (1:22)', {
-  ecmaVersion: 11
+  ecmaVersion: 11,
+  loose: false
+});
+
+testFail("import('test.js')", 'Unexpected token (1:6)', {
+  ecmaVersion: 10,
+  loose: false,
+  sourceType: 'module'
+});
+
+testFail("import()", 'import() requires exactly one argument (1:0)', {
+  ecmaVersion: 11,
+  loose: false
+});
+
+testFail("import(a, b)", 'import() requires exactly one argument (1:0)', {
+  ecmaVersion: 11,
+  loose: false
+});
+
+testFail("import(...[a])", '... is not allowed in import() (1:7)', {
+  ecmaVersion: 11,
+  loose: false
+});
+
+testFail("import(source,)", 'Unexpected token (1:14)', {
+  ecmaVersion: 11,
+  loose: false
+});
+
+testFail("new import(source)", 'Cannot use new with import(...) (1:4)', {
+  ecmaVersion: 11,
+  loose: false
 });


### PR DESCRIPTION
This adds dynamic import support to Acorn. I mostly just copied this out of my existing acorn plugin: https://github.com/kesne/acorn-dynamic-import.

Fixes #833, #832.