### PR TITLE
Disallow let as identifier name in patterns

### DIFF
--- a/acorn/src/lval.js
+++ b/acorn/src/lval.js
@@ -1,7 +1,7 @@
 import {types as tt} from "./tokentype"
 import {Parser} from "./state"
 import {has} from "./util"
-import {BIND_NONE, BIND_OUTSIDE} from "./scopeflags"
+import {BIND_NONE, BIND_OUTSIDE, BIND_LEXICAL} from "./scopeflags"
 
 const pp = Parser.prototype
 
@@ -189,6 +189,8 @@ pp.parseMaybeDefault = function(startPos, startLoc, left) {
 pp.checkLVal = function(expr, bindingType = BIND_NONE, checkClashes) {
   switch (expr.type) {
   case "Identifier":
+    if (bindingType === BIND_LEXICAL && expr.name === "let")
+      this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name")
     if (this.strict && this.reservedWordsStrictBind.test(expr.name))
       this.raiseRecoverable(expr.start, (bindingType ? "Binding " : "Assigning to ") + expr.name + " in strict mode")
     if (checkClashes) {

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -501,9 +501,6 @@ pp.parseVar = function(node, isFor, kind) {
 }
 
 pp.parseVarId = function(decl, kind) {
-  if ((kind === "const" || kind === "let") && this.isContextual("let")) {
-    this.raiseRecoverable(this.start, "let is disallowed as a lexically bound name")
-  }
   decl.id = this.parseBindingAtom()
   this.checkLVal(decl.id, kind === "var" ? BIND_VAR : BIND_LEXICAL, false)
 }

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -13409,9 +13409,25 @@ testFail("let let", "let is disallowed as a lexically bound name (1:4)", {ecmaVe
 
 testFail("const let", "let is disallowed as a lexically bound name (1:6)", {ecmaVersion: 6})
 
-testFail("'use strict'; let let", "let is disallowed as a lexically bound name (1:18)", {ecmaVersion: 6})
+testFail("let { let } = {};", "let is disallowed as a lexically bound name (1:6)", {ecmaVersion: 6})
 
-testFail("'use strict'; const let", "let is disallowed as a lexically bound name (1:20)", {ecmaVersion: 6})
+testFail("const { let } = {};", "let is disallowed as a lexically bound name (1:8)", {ecmaVersion: 6})
+
+testFail("let [let] = [];", "let is disallowed as a lexically bound name (1:5)", {ecmaVersion: 6})
+
+testFail("const [let] = [];", "let is disallowed as a lexically bound name (1:7)", {ecmaVersion: 6})
+
+testFail("'use strict'; let let", "The keyword 'let' is reserved (1:18)", {ecmaVersion: 6})
+
+testFail("'use strict'; const let", "The keyword 'let' is reserved (1:20)", {ecmaVersion: 6})
+
+testFail("'use strict'; let { let } = {};", "The keyword 'let' is reserved (1:20)", {ecmaVersion: 6})
+
+testFail("'use strict'; const { let } = {};", "The keyword 'let' is reserved (1:22)", {ecmaVersion: 6})
+
+testFail("'use strict'; let [let] = [];", "The keyword 'let' is reserved (1:19)", {ecmaVersion: 6})
+
+testFail("'use strict'; const [let] = [];", "The keyword 'let' is reserved (1:21)", {ecmaVersion: 6})
 
 test("if (1) let\n{}", {}, {ecmaVersion: 6})
 

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -13403,7 +13403,6 @@ test("var let = 1", {
   ]
 }, {ecmaVersion: 6})
 
-testFail("'use strict'; let + 1", "The keyword 'let' is reserved (1:14)", {ecmaVersion: 6})
 
 testFail("let let", "let is disallowed as a lexically bound name (1:4)", {ecmaVersion: 6})
 
@@ -13416,6 +13415,8 @@ testFail("const { let } = {};", "let is disallowed as a lexically bound name (1:
 testFail("let [let] = [];", "let is disallowed as a lexically bound name (1:5)", {ecmaVersion: 6})
 
 testFail("const [let] = [];", "let is disallowed as a lexically bound name (1:7)", {ecmaVersion: 6})
+
+testFail("'use strict'; let + 1", "The keyword 'let' is reserved (1:14)", {ecmaVersion: 6})
 
 testFail("'use strict'; let let", "The keyword 'let' is reserved (1:18)", {ecmaVersion: 6})
 


### PR DESCRIPTION
fixes #837 

Similar change to https://github.com/babel/babel/pull/10099.

The changes here do two things:
1. Throw a recoverable error when `let` is used as an identifier as a lexically bound name in object/array patterns. [Relevant part of spec](https://tc39.es/ecma262/#sec-let-and-const-declarations-static-semantics-early-errors).
1. Change the error message for the same pattern above to correctly report `let` as a reserved word in strict mode. [Relevant part of spec](https://tc39.es/ecma262/#sec-keywords).

I'm definitely no expert at reading the spec, so please let me know if something is amiss. Thanks!