### PR TITLE
Add .npmrc to prevent lockfile from being generated

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false


### PR DESCRIPTION
While working on https://github.com/acornjs/acorn/pull/839 I noticed that a lockfile isn't committed (but is generated by anyone using a recent version of npm). This will prevent it from being generated in the first place.