### PR TITLE
update options.allowReserved in d.ts follow README

### DIFF
--- a/acorn/dist/acorn.d.ts
+++ b/acorn/dist/acorn.d.ts
@@ -16,7 +16,7 @@ declare namespace acorn {
     sourceType?: 'script' | 'module'
     onInsertedSemicolon?: (lastTokEnd: number, lastTokEndLoc?: Position) => void
     onTrailingComma?: (lastTokEnd: number, lastTokEndLoc?: Position) => void
-    allowReserved?: boolean
+    allowReserved?: boolean | 'never'
     allowReturnOutsideFunction?: boolean
     allowImportExportEverywhere?: boolean
     allowAwaitOutsideFunction?: boolean


### PR DESCRIPTION
> **allowReserved**: If `false`, using a reserved word will generate an error. Defaults to `true` for `ecmaVersion` 3, `false` for higher versions. When given the value `"never"`, reserved words and keywords can also not be used as property names (as in Internet Explorer's old parser).

And I'm not sure, should this line change to `    if (options.allowReserved!==true) {`?

https://github.com/acornjs/acorn/blob/9c993564460cb92b08808f189b9669d3e9ccea38/acorn/src/state.js#L14