### PR TITLE
Update dynamic imports AST

### DIFF
--- a/acorn-loose/src/expression.js
+++ b/acorn-loose/src/expression.js
@@ -297,8 +297,8 @@ lp.parseExprAtom = function() {
     return this.parseTemplate()
 
   case tt._import:
-    if (this.options.ecmaVersion > 10) {
-      return this.parseDynamicImport()
+    if (this.options.ecmaVersion >= 11) {
+      return this.parseExprImport()
     } else {
       return this.dummyIdent()
     }
@@ -308,10 +308,21 @@ lp.parseExprAtom = function() {
   }
 }
 
-lp.parseDynamicImport = function() {
+lp.parseExprImport = function() {
   const node = this.startNode()
-  this.next()
-  return this.finishNode(node, "Import")
+  this.next() // skip `import`
+  switch (this.tok.type) {
+  case tt.parenL:
+    return this.parseDynamicImport(node)
+  default:
+    node.name = "import"
+    return this.finishNode(node, "Identifier")
+  }
+}
+
+lp.parseDynamicImport = function(node) {
+  node.source = this.parseExprList(tt.parenR)[0] || this.dummyString()
+  return this.finishNode(node, "ImportExpression")
 }
 
 lp.parseNew = function() {

--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -439,13 +439,13 @@ pp.parseDynamicImport = function(node) {
   node.source = this.parseMaybeAssign()
 
   // Verify ending.
-  const commaPos = this.start
-  const commaExists = this.eat(tt.comma)
   if (!this.eat(tt.parenR)) {
-    this.unexpected(commaPos)
-  }
-  if (commaExists) {
-    this.raiseRecoverable(commaPos, "Trailing comma is not allowed in import()")
+    const errorPos = this.start
+    if (this.eat(tt.comma) && this.eat(tt.parenR)) {
+      this.raiseRecoverable(errorPos, "Trailing comma is not allowed in import()")
+    } else {
+      this.unexpected(errorPos)
+    }
   }
 
   return this.finishNode(node, "ImportExpression")

--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -439,9 +439,6 @@ pp.parseDynamicImport = function(node) {
   this.next() // skip `(`
 
   // Parse node.source.
-  if (this.type === tt.ellipsis) {
-    this.raise(this.start, "... is not allowed in import()")
-  }
   node.source = this.parseMaybeAssign()
 
   // Verify ending.

--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -314,7 +314,7 @@ pp.parseSubscript = function(base, startPos, startLoc, noCalls, maybeAsyncArrow)
 // `new`, or an expression wrapped in punctuation like `()`, `[]`,
 // or `{}`.
 
-pp.parseExprAtom = function(refDestructuringErrors, noDynamicImport) {
+pp.parseExprAtom = function(refDestructuringErrors) {
   // If a division operator appears in an expression position, the
   // tokenizer got confused, and we force it to read a regexp instead.
   if (this.type === tt.slash) this.readRegexp()
@@ -411,7 +411,7 @@ pp.parseExprAtom = function(refDestructuringErrors, noDynamicImport) {
 
   case tt._import:
     if (this.options.ecmaVersion >= 11) {
-      return this.parseExprImport(noDynamicImport)
+      return this.parseExprImport()
     } else {
       return this.unexpected()
     }
@@ -421,14 +421,11 @@ pp.parseExprAtom = function(refDestructuringErrors, noDynamicImport) {
   }
 }
 
-pp.parseExprImport = function(noDynamicImport) {
+pp.parseExprImport = function() {
   const node = this.startNode()
   this.next() // skip `import`
   switch (this.type) {
   case tt.parenL:
-    if (noDynamicImport) {
-      this.raise(this.start, "Cannot use new with import()")
-    }
     return this.parseDynamicImport(node)
   default:
     this.unexpected()
@@ -561,8 +558,11 @@ pp.parseNew = function() {
       this.raiseRecoverable(node.start, "new.target can only be used in functions")
     return this.finishNode(node, "MetaProperty")
   }
-  let startPos = this.start, startLoc = this.startLoc
-  node.callee = this.parseSubscripts(this.parseExprAtom(null, true), startPos, startLoc, true)
+  let startPos = this.start, startLoc = this.startLoc, isImport = this.type === tt._import
+  node.callee = this.parseSubscripts(this.parseExprAtom(), startPos, startLoc, true)
+  if (isImport && node.callee.type === "ImportExpression") {
+    this.raise(startPos, "Cannot use new with import()")
+  }
   if (this.eat(tt.parenL)) node.arguments = this.parseExprList(tt.parenR, this.options.ecmaVersion >= 8, false)
   else node.arguments = empty
   return this.finishNode(node, "NewExpression")

--- a/test/tests-dynamic-import.js
+++ b/test/tests-dynamic-import.js
@@ -240,7 +240,7 @@ testFail("import(source,)", 'Trailing comma is not allowed in import() (1:13)', 
   loose: false
 });
 
-testFail("new import(source)", 'Cannot use new with import() (1:10)', {
+testFail("new import(source)", 'Cannot use new with import() (1:4)', {
   ecmaVersion: 11,
   loose: false
 });

--- a/test/tests-dynamic-import.js
+++ b/test/tests-dynamic-import.js
@@ -230,7 +230,7 @@ testFail("import(a, b)", 'Unexpected token (1:8)', {
   loose: false
 });
 
-testFail("import(...[a])", '... is not allowed in import() (1:7)', {
+testFail("import(...[a])", 'Unexpected token (1:7)', {
   ecmaVersion: 11,
   loose: false
 });

--- a/test/tests-dynamic-import.js
+++ b/test/tests-dynamic-import.js
@@ -17,23 +17,63 @@ test(
         start: 0,
         end: 26,
         expression: {
-          type: 'CallExpression',
+          type: 'ImportExpression',
           start: 0,
           end: 26,
-          callee: { type: 'Import', start: 0, end: 6 },
-          arguments: [
-            {
-              type: 'Literal',
-              start: 7,
-              end: 25,
-              value: 'dynamicImport.js',
-              raw: "'dynamicImport.js'"
-            }
-          ]
+          source: {
+            type: 'Literal',
+            start: 7,
+            end: 25,
+            value: 'dynamicImport.js',
+            raw: "'dynamicImport.js'"
+          }
         }
       }
     ],
     sourceType: 'script'
+  },
+  { ecmaVersion: 11 }
+);
+
+// Assignment is OK.
+test(
+  "import(a = 'dynamicImport.js')",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 30,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 30,
+        "expression": {
+          "type": "ImportExpression",
+          "start": 0,
+          "end": 30,
+          "source": {
+            "type": "AssignmentExpression",
+            "start": 7,
+            "end": 29,
+            "operator": "=",
+            "left": {
+              "type": "Identifier",
+              "start": 7,
+              "end": 8,
+              "name": "a"
+            },
+            "right": {
+              "type": "Literal",
+              "start": 11,
+              "end": 29,
+              "value": "dynamicImport.js",
+              "raw": "'dynamicImport.js'"
+            }
+          }
+        }
+      }
+    ],
+    "sourceType": "script"
   },
   { ecmaVersion: 11 }
 );
@@ -69,11 +109,10 @@ test(
                 end: 36,
                 delegate: false,
                 argument: {
-                  type: 'CallExpression',
+                  type: 'ImportExpression',
                   start: 22,
                   end: 36,
-                  callee: { type: 'Import', start: 22, end: 28 },
-                  arguments: [{ type: 'Literal', start: 29, end: 35, value: 'http', raw: "'http'" }]
+                  source: { type: 'Literal', start: 29, end: 35, value: 'http', raw: "'http'" }
                 }
               }
             }
@@ -82,6 +121,85 @@ test(
       }
     ],
     sourceType: 'script'
+  },
+  { ecmaVersion: 11 }
+);
+
+// `new import(s)` is syntax error, but `new (import(s))` is not.
+test(
+  "new (import(s))",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 15,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 15,
+        "expression": {
+          "type": "NewExpression",
+          "start": 0,
+          "end": 15,
+          "callee": {
+            "type": "ImportExpression",
+            "start": 5,
+            "end": 14,
+            "source": {
+              "type": "Identifier",
+              "start": 12,
+              "end": 13,
+              "name": "s"
+            }
+          },
+          "arguments": []
+        }
+      }
+    ],
+    "sourceType": "script"
+  },
+  { ecmaVersion: 11 }
+);
+
+// `import(s,t)` is syntax error, but `import((s,t))` is not.
+test(
+  "import((s,t))",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 13,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 13,
+        "expression": {
+          "type": "ImportExpression",
+          "start": 0,
+          "end": 13,
+          "source": {
+            "type": "SequenceExpression",
+            "start": 8,
+            "end": 11,
+            "expressions": [
+              {
+                "type": "Identifier",
+                "start": 8,
+                "end": 9,
+                "name": "s"
+              },
+              {
+                "type": "Identifier",
+                "start": 10,
+                "end": 11,
+                "name": "t"
+              }
+            ]
+          }
+        }
+      }
+    ],
+    "sourceType": "script"
   },
   { ecmaVersion: 11 }
 );
@@ -102,12 +220,12 @@ testFail("import('test.js')", 'Unexpected token (1:6)', {
   sourceType: 'module'
 });
 
-testFail("import()", 'import() requires exactly one argument (1:0)', {
+testFail("import()", 'Unexpected token (1:7)', {
   ecmaVersion: 11,
   loose: false
 });
 
-testFail("import(a, b)", 'import() requires exactly one argument (1:0)', {
+testFail("import(a, b)", 'Unexpected token (1:8)', {
   ecmaVersion: 11,
   loose: false
 });
@@ -117,12 +235,17 @@ testFail("import(...[a])", '... is not allowed in import() (1:7)', {
   loose: false
 });
 
-testFail("import(source,)", 'Unexpected token (1:14)', {
+testFail("import(source,)", 'Trailing comma is not allowed in import() (1:13)', {
   ecmaVersion: 11,
   loose: false
 });
 
-testFail("new import(source)", 'Cannot use new with import(...) (1:4)', {
+testFail("new import(source)", 'Cannot use new with import() (1:10)', {
+  ecmaVersion: 11,
+  loose: false
+});
+
+testFail("(import)(s)", 'Unexpected token (1:7)', {
   ecmaVersion: 11,
   loose: false
 });


### PR DESCRIPTION
This PR changes the AST of dynamic imports as following https://github.com/estree/estree/pull/198. Please don't merge this PR til https://github.com/estree/estree/pull/198 was merged. (https://github.com/estree/estree/pull/198 is waiting for @adrianheine's response.)

This PR adds the second parameter to `parser.parseExprAtom()` method to make the following behavior:

- `new import(s)` is a syntax error.
- `new (import(s))` is not a syntax error. (though it's a runtime type error.)
- `new import.meta(s)` is not a syntax error in the future. (though it will be a runtime type error.)

Also, this PR adds some test cases:

- valid:
    - `import(a = 'dynamicImport.js')`
    - `new (import(s))`
    - `import((s,t))`
- invalid
    - `(import)(s)`

---
> fixes #833, fixes #832