### PR TITLE
recorrect changelog

### DIFF
--- a/acorn/CHANGELOG.md
+++ b/acorn/CHANGELOG.md
@@ -30,9 +30,9 @@ Disallow binding `let` in patterns.
 
 ### New features
 
-Support bigint syntax with `ecmaVersion` >= 10.
+Support bigint syntax with `ecmaVersion` >= 11.
 
-Support dynamic `import` syntax with `ecmaVersion` >= 10.
+Support dynamic `import` syntax with `ecmaVersion` >= 11.
 
 Upgrade to Unicode version 12.
 

--- a/acorn/README.md
+++ b/acorn/README.md
@@ -52,9 +52,10 @@ Options can be provided by passing a second argument, which should be
 an object containing any of these fields:
 
 - **ecmaVersion**: Indicates the ECMAScript version to parse. Must be
-  either 3, 5, 6 (2015), 7 (2016), 8 (2017), 9 (2018) or 10 (2019, partial
-  support). This influences support for strict mode, the set of
-  reserved words, and support for new syntax features. Default is 10.
+  either 3, 5, 6 (2015), 7 (2016), 8 (2017), 9 (2018), 10 (2019) or 11
+  (2020, partial support). This influences support for strict mode,
+  the set of reserved words, and support for new syntax features.
+  Default is 10.
 
   **NOTE**: Only 'stage 4' (finalized) ECMAScript features are being
   implemented by Acorn. Other proposed new features can be implemented

--- a/acorn/dist/acorn.d.ts
+++ b/acorn/dist/acorn.d.ts
@@ -12,7 +12,7 @@ declare namespace acorn {
   }
 
   interface Options {
-    ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 2015 | 2016 | 2017 | 2018 | 2019
+    ecmaVersion?: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020
     sourceType?: 'script' | 'module'
     onInsertedSemicolon?: (lastTokEnd: number, lastTokEndLoc?: Position) => void
     onTrailingComma?: (lastTokEnd: number, lastTokEndLoc?: Position) => void


### PR DESCRIPTION
bigint and dynamic import need ecmaVersion >= 11 in my test.

and after checking the source, I think it's not a mistake in soure (`> 10` are `>=11` now, which shows clear intention, and indeed ES 10 spec does not includes bigint and import), but in changelog.

one thing more: should the default ecmaVersion change to 11 too?