### PR TITLE
Fix #867: add support for specifying the start offset/line/column

### DIFF
--- a/acorn/src/location.js
+++ b/acorn/src/location.js
@@ -11,6 +11,10 @@ const pp = Parser.prototype
 
 pp.raise = function(pos, message) {
   let loc = getLineInfo(this.input, pos)
+  if (loc.line === 0) {
+    loc.column += this.dispColumn
+  }
+  loc.line += this.dispLine
   message += " (" + loc.line + ":" + loc.column + ")"
   let err = new SyntaxError(message)
   err.pos = pos; err.loc = loc; err.raisedAt = this.pos
@@ -21,6 +25,7 @@ pp.raiseRecoverable = pp.raise
 
 pp.curPosition = function() {
   if (this.options.locations) {
-    return new Position(this.curLine, this.pos - this.lineStart)
+    let column = this.pos - this.lineStart
+    return new Position(this.curLine + this.dispLine, this.curLine === 1 ? column + this.dispColumn : column)
   }
 }

--- a/acorn/src/node.js
+++ b/acorn/src/node.js
@@ -20,18 +20,18 @@ export class Node {
 const pp = Parser.prototype
 
 pp.startNode = function() {
-  return new Node(this, this.start, this.startLoc)
+  return new Node(this, this.start + this.dispOffset, this.startLoc)
 }
 
 pp.startNodeAt = function(pos, loc) {
-  return new Node(this, pos, loc)
+  return new Node(this, pos + this.dispOffset, loc)
 }
 
 // Finish an AST node, adding `type` and `end` properties.
 
 function finishNodeAt(node, type, pos, loc) {
   node.type = type
-  node.end = pos
+  node.end = pos + this.dispOffset
   if (this.options.locations)
     node.loc.end = loc
   if (this.options.ranges)

--- a/acorn/src/options.js
+++ b/acorn/src/options.js
@@ -86,7 +86,16 @@ export const defaultOptions = {
   directSourceFile: null,
   // When enabled, parenthesized expressions are represented by
   // (non-standard) ParenthesizedExpression nodes
-  preserveParens: false
+  preserveParens: false,
+  // When parsing JavaScript as part of a different file, you can set this
+  // option to set the start offset.
+  startOffset: 0,
+  // When parsing JavaScript as part of a different file, you can set this
+  // option to set the start line number.
+  startLine: 1,
+  // When parsing JavaScript as part of a different file, you can set this
+  // option to set the start column number.
+  startColumn: 0
 }
 
 // Interpret and default an options object

--- a/acorn/src/state.js
+++ b/acorn/src/state.js
@@ -46,6 +46,11 @@ export class Parser {
     this.value = null
     // Its start and end offset
     this.start = this.end = this.pos
+    // Additional displacement that should be added to the
+    // eventual positions
+    this.dispOffset = options.startOffset
+    this.dispLine = options.startLine - 1
+    this.dispColumn = options.startColumn
     // And, if locations are used, the {line, column} object
     // corresponding to those offsets
     this.startLoc = this.endLoc = this.curPosition()

--- a/test/tests.js
+++ b/test/tests.js
@@ -29464,3 +29464,79 @@ test("/**/ --> comment\n", {})
 test("x.class++", {})
 
 testFail("½", "Unexpected character '½' (1:0)")
+
+test("1 + 2", {
+  type: "Program",
+  start: 15,
+  end: 20,
+  loc: { 
+    start: { line: 2, column: 4 },
+    end: { line: 2, column: 9 }
+  },
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 15,
+      end: 20,
+      loc: { start: { line: 2, column: 4 }, end: { line: 2, column: 9 } },
+      expression: {
+        type: "BinaryExpression",
+        operator: "+",
+        start: 15,
+        end: 20,
+        left: { type: "Literal", start: 15, end: 16, value: 1 },
+        right: { type: "Literal", start: 19, end: 20, value: 2 }
+      }
+    }
+  ]
+}, {
+  loose: false,
+  startOffset: 15,
+  startColumn: 4,
+  startLine: 2,
+  locations: true
+})
+
+
+test("\n\n5 + 1\n\nfoo", {
+  type: "Program",
+  start: 15,
+  end: 27,
+  loc: {
+    start: { line: 2, column: 4 },
+    end: { line: 6, column: 3 }
+  },
+  body: [
+    {
+      type: "ExpressionStatement",
+      start: 17,
+      end: 22,
+      loc: { start: { line: 4, column: 0 }, end: { line: 4, column: 5 } },
+      expression: {
+        type: "BinaryExpression",
+        start: 17,
+        end: 22,
+        loc: { start: { line: 4, column: 0 }, end: { line: 4, column: 5 } }
+      }
+    },
+    {
+      type: "ExpressionStatement",
+      start: 24,
+      end: 27,
+      loc: { start: { line: 6, column: 0 }, end: { line: 6, column: 3 } },
+      expression: {
+        type: "Identifier",
+        start: 24,
+        end: 27,
+        loc: { start: { line: 6, column: 0 }, end: { line: 6, column: 3 } }
+      }
+    }
+  ]
+}, {
+  loose: false,
+  startOffset: 15,
+  startColumn: 4,
+  startLine: 2,
+  locations: true
+})
+


### PR DESCRIPTION
As promised, here are the changes for acorn to support a user-specified offset/line/column as proposed in #867.

Some remarks:

 - I didn't bother updating the loose parser, as I see no use-case for this at the moment.
 - The current implementation might result in a slight decrease in performance, but I didn't do any benchmarks. Just a thought, but maybe something like a build option could be added to enable this feature when it is needed?
 - I wrote two simple tests, and naively assumed that everything works OK for all of the other cases as well, given that these are very small changes.