### PR TITLE
Request: give token types and etc to plugins

### DIFF
--- a/acorn/src/index.js
+++ b/acorn/src/index.js
@@ -22,17 +22,57 @@ import "./expression"
 import "./location"
 import "./scope"
 
-export {Parser} from "./state"
-export {defaultOptions} from "./options"
-export {Position, SourceLocation, getLineInfo} from "./locutil"
-export {Node} from "./node"
-export {TokenType, types as tokTypes, keywords as keywordTypes} from "./tokentype"
-export {TokContext, types as tokContexts} from "./tokencontext"
-export {isIdentifierChar, isIdentifierStart} from "./identifier"
-export {Token} from "./tokenize"
-export {isNewLine, lineBreak, lineBreakG, nonASCIIwhitespace} from "./whitespace"
+import {defaultOptions} from "./options"
+import {Position, SourceLocation, getLineInfo} from "./locutil"
+import {Node} from "./node"
+import {TokenType, types as tokTypes, keywords as keywordTypes} from "./tokentype"
+import {TokContext, types as tokContexts} from "./tokencontext"
+import {isIdentifierChar, isIdentifierStart} from "./identifier"
+import {Token} from "./tokenize"
+import {isNewLine, lineBreak, lineBreakG, nonASCIIwhitespace} from "./whitespace"
 
 export const version = "7.0.0"
+export {
+  Parser,
+  defaultOptions,
+  Position,
+  SourceLocation,
+  getLineInfo,
+  Node,
+  TokenType,
+  tokTypes,
+  keywordTypes,
+  TokContext,
+  tokContexts,
+  isIdentifierChar,
+  isIdentifierStart,
+  Token,
+  isNewLine,
+  lineBreak,
+  lineBreakG,
+  nonASCIIwhitespace
+}
+
+Parser.acorn = {
+  version,
+  defaultOptions,
+  Position,
+  SourceLocation,
+  getLineInfo,
+  Node,
+  TokenType,
+  tokTypes,
+  keywordTypes,
+  TokContext,
+  tokContexts,
+  isIdentifierChar,
+  isIdentifierStart,
+  Token,
+  isNewLine,
+  lineBreak,
+  lineBreakG,
+  nonASCIIwhitespace
+}
 
 // The main exported interface (under `self.acorn` when in the
 // browser) is a `parse` function that takes a code string and


### PR DESCRIPTION
Hello.

Since the installation problem has re-raised due to 7.0.0, I want to revisit #824.

**Context:**

Issue is https://github.com/eslint/eslint/issues/12119.

`espree`, the default parser of ESLint, depends on `acorn` and `acorn-jsx`.

```
eslint
└ espree
   ├ acorn 7
   └ acorn-jsx (requires acorn 6 or 7 as a peer dependency)
```

This expected to work fine because the peer dependency requirement of `acorn-jsx` satisfies. But, in fact, `npm` guarantees the peer dependency requirements satisfy, but doesn't guarantee the `acorn` that `espree` imports and the `acorn` that `acorn-jsx` imports are the same one.

For example, if an end-user installed webpack as well...

```
webpack
└ acorn 6
eslint
└ espree
   ├ acorn 7
   └ acorn-jsx (requires acorn 6 or 7 as a peer dependency)
```

Then `npm` can dedupe those...

```
webpack
acorn 6 (from webpack)
eslint
espree (from eslint)
└ acorn 7 (pinned in `espree` directory to avoid conflicts)
acorn-jsx (from espree; requires acorn 6 or 7 as a peer dependency)
```

OK, the peer dependency requirement of the `acorn-jsx` still satisfies. It's a right installation. But broken. The `acorn-jsx` imports Webpack's `acorn`. The `espree` imports own `acorn`. So `acorn.tokTypes` gets different instances.

Here, please mind two `acorn`s are not used at the same time. One is used by Webpack. One is used by ESLint. End users cannot solve this problem. They only can choose to break either ESLint or Webpack or give up the use of new features of those.

There are a lot of packages that depend on `acorn`. It means that people can depend on `acorn` indirectly easily, then `acorn`'s plugins are very fragile.

**A solution:**

I think that the root cause is acorn's plugins cannot get the applied `acorn` entity. The peer dependencies functionality doesn't guarantee `acorn` entity is unique because of indirect dependencies.

This PR lets plugins access `tokTypes` and etc via `Parser.acorn.tokTypes` and other members. The `Parser` is the `acorn` entity that the plugin was applied.

Maybe there are other solutions, but this is an idea. Would you consider to solve this problem?