### PR TITLE
Add link to MDN "method properties" doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
-# Acorn
+# Acorn AST walker
 
-[![Build Status](https://travis-ci.org/acornjs/acorn.svg?branch=master)](https://travis-ci.org/acornjs/acorn)
-[![NPM version](https://img.shields.io/npm/v/acorn.svg)](https://www.npmjs.com/package/acorn)
-[![CDNJS](https://img.shields.io/cdnjs/v/acorn.svg)](https://cdnjs.com/libraries/acorn)  
-
-A tiny, fast JavaScript parser, written completely in JavaScript.
+An abstract syntax tree walker for the
+[ESTree](https://github.com/estree/estree) format.
 
 ## Community
 
 Acorn is open source software released under an
-[MIT license](https://github.com/acornjs/acorn/blob/master/acorn/LICENSE).
+[MIT license](https://github.com/acornjs/acorn/blob/master/acorn-walk/LICENSE).
 
 You are welcome to
 [report bugs](https://github.com/acornjs/acorn/issues) or create pull
@@ -17,18 +14,15 @@ requests on [github](https://github.com/acornjs/acorn). For questions
 and discussion, please use the
 [Tern discussion forum](https://discuss.ternjs.net).
 
-## Packages
+## Installation
 
-This repository holds three packages:
+The easiest way to install acorn is from [`npm`](https://www.npmjs.com/):
 
- - [acorn](https://github.com/acornjs/acorn/blob/master/acorn/): The
-   main parser
- - [acorn-loose](https://github.com/acornjs/acorn/blob/master/acorn-loose/): The
-   error-tolerant parser
- - [acorn-walk](https://github.com/acornjs/acorn/blob/master/acorn-walk/): The
-   syntax tree walker
+```sh
+npm install acorn-walk
+```
 
-To build the content of the repository, run `npm install`.
+Alternately, you can download the source and build acorn yourself:
 
 ```sh
 git clone https://github.com/acornjs/acorn.git
@@ -36,56 +30,98 @@ cd acorn
 npm install
 ```
 
-## Plugin developments
+## Interface
 
-Acorn is designed to support plugins which can, within reasonable
-bounds, redefine the way the parser works. Plugins can add new token
-types and new tokenizer contexts (if necessary), and extend methods in
-the parser object. This is not a clean, elegant API—using it requires
-an understanding of Acorn's internals, and plugins are likely to break
-whenever those internals are significantly changed. But still, it is
-_possible_, in this way, to create parsers for JavaScript dialects
-without forking all of Acorn. And in principle it is even possible to
-combine such plugins, so that if you have, for example, a plugin for
-parsing types and a plugin for parsing JSX-style XML literals, you
-could load them both and parse code with both JSX tags and types.
+An algorithm for recursing through a syntax tree is stored as an
+object, with a property for each tree node type holding a function
+that will recurse through such a node. There are several ways to run
+such a walker.
 
-A plugin is a function from a parser class to an extended parser
-class. Plugins can be used by simply applying them to the `Parser`
-class (or a version of that already extended by another plugin). But
-because that gets a little awkward, syntactically, when you are using
-multiple plugins, the static method `Parser.extend` can be called with
-any number of plugin values as arguments to create a `Parser` class
-extended by all those plugins. You'll usually want to create such an
-extended class only once, and then repeatedly call `parse` on it, to
-avoid needlessly confusing the JavaScript engine's optimizer.
+**simple**`(node, visitors, base, state)` does a 'simple' walk over a
+tree. `node` should be the AST node to walk, and `visitors` [an object
+with properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions)
+whose names correspond to node types in the [ESTree
+spec](https://github.com/estree/estree). The properties should contain
+functions that will be called with the node object and, if applicable
+the state at that point. The last two arguments are optional. `base`
+is a walker algorithm, and `state` is a start state. The default
+walker will simply visit all statements and expressions and not
+produce a meaningful state. (An example of a use of state is to track
+scope at each point in the tree.)
 
-```javascript
-const {Parser} = require("acorn")
+```js
+const acorn = require("acorn")
+const walk = require("acorn-walk")
 
-const MyParser = Parser.extend(
-  require("acorn-jsx")(),
-  require("acorn-bigint")
-)
-console.log(MyParser.parse("// Some bigint + JSX code"))
-```
-
-Plugins override methods in their new parser class to implement
-additional functionality. It is recommended for a plugin package to
-export its plugin function as its default value or, if it takes
-configuration parameters, to export a constructor function that
-creates the plugin function.
-
-This is what a trivial plugin, which adds a bit of code to the
-`readToken` method, might look like:
-
-```javascript
-module.exports = function noisyReadToken(Parser) {
-  return class extends Parser {
-    readToken(code) {
-      console.log("Reading a token!")
-      super.readToken(code)
-    }
+walk.simple(acorn.parse("let x = 10"), {
+  Literal(node) {
+    console.log(`Found a literal: ${node.value}`)
   }
-}
+})
 ```
+
+**ancestor**`(node, visitors, base, state)` does a 'simple' walk over
+a tree, building up an array of ancestor nodes (including the current node)
+and passing the array to the callbacks as a third parameter.
+
+```js
+const acorn = require("acorn")
+const walk = require("acorn-walk")
+
+walk.ancestor(acorn.parse("foo('hi')"), {
+  Literal(_, ancestors) {
+    console.log("This literal's ancestors are:", ancestors.map(n => n.type))
+  }
+})
+```
+
+**recursive**`(node, state, functions, base)` does a 'recursive'
+walk, where the walker functions are responsible for continuing the
+walk on the child nodes of their target node. `state` is the start
+state, and `functions` should contain an object that maps node types
+to walker functions. Such functions are called with `(node, state, c)`
+arguments, and can cause the walk to continue on a sub-node by calling
+the `c` argument on it with `(node, state)` arguments. The optional
+`base` argument provides the fallback walker functions for node types
+that aren't handled in the `functions` object. If not given, the
+default walkers will be used.
+
+**make**`(functions, base)` builds a new walker object by using the
+walker functions in `functions` and filling in the missing ones by
+taking defaults from `base`.
+
+**full**`(node, callback, base, state)` does a 'full' walk over a
+tree, calling the callback with the arguments (node, state, type) for
+each node
+
+**fullAncestor**`(node, callback, base, state)` does a 'full' walk
+over a tree, building up an array of ancestor nodes (including the
+current node) and passing the array to the callbacks as a third
+parameter.
+
+```js
+const acorn = require("acorn")
+const walk = require("acorn-walk")
+
+walk.full(acorn.parse("1 + 1"), node => {
+  console.log(`There's a ${node.type} node at ${node.ch}`)
+})
+```
+
+**findNodeAt**`(node, start, end, test, base, state)` tries to locate
+a node in a tree at the given start and/or end offsets, which
+satisfies the predicate `test`. `start` and `end` can be either `null`
+(as wildcard) or a number. `test` may be a string (indicating a node
+type) or a function that takes `(nodeType, node)` arguments and
+returns a boolean indicating whether this node is interesting. `base`
+and `state` are optional, and can be used to specify a custom walker.
+Nodes are tested from inner to outer, so if two nodes match the
+boundaries, the inner one will be preferred.
+
+**findNodeAround**`(node, pos, test, base, state)` is a lot like
+`findNodeAt`, but will match any node that exists 'around' (spanning)
+the given position.
+
+**findNodeAfter**`(node, pos, test, base, state)` is similar to
+`findNodeAround`, but will match all nodes *after* the given position
+(testing outer nodes before inner nodes).


### PR DESCRIPTION
IDK if this is the right place to do it, but the method definitions syntax was confusing to me when reading the docs, purely because I had not seen that syntax before. This change at least adds a link to the docs about them for the `visitors` mention in the README.