### PR TITLE
Add link to MDN "method properties" doc (take2)

### DIFF
--- a/acorn-walk/README.md
+++ b/acorn-walk/README.md
@@ -38,8 +38,9 @@ that will recurse through such a node. There are several ways to run
 such a walker.
 
 **simple**`(node, visitors, base, state)` does a 'simple' walk over a
-tree. `node` should be the AST node to walk, and `visitors` an object
-with properties whose names correspond to node types in the [ESTree
+tree. `node` should be the AST node to walk, and `visitors` [an object
+with properties](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Method_definitions)
+whose names correspond to node types in the [ESTree
 spec](https://github.com/estree/estree). The properties should contain
 functions that will be called with the node object and, if applicable
 the state at that point. The last two arguments are optional. `base`


### PR DESCRIPTION
IDK if this is the right place to do it, but the method definitions syntax was confusing to me when reading the docs, purely because I had not seen that syntax before. This change at least adds a link to the docs about them for the `visitors` mention in the README.

P.S. - prior PR (#882) somehow overwrote the main README?