### PR TITLE
update test262

### DIFF
--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -546,6 +546,7 @@ pp.parseParenArrowList = function(startPos, startLoc, exprList) {
 const empty = []
 
 pp.parseNew = function() {
+  if (this.containsEsc) this.raiseRecoverable(this.start, "Escape sequence in keyword new")
   let node = this.startNode()
   let meta = this.parseIdent(true)
   if (this.options.ecmaVersion >= 6 && this.eat(tt.dot)) {
@@ -929,7 +930,7 @@ pp.parseIdent = function(liberal, isBinding) {
   } else {
     this.unexpected()
   }
-  this.next()
+  this.next(!!liberal)
   this.finishNode(node, "Identifier")
   if (!liberal) {
     this.checkUnreserved(node)

--- a/acorn/src/tokenize.js
+++ b/acorn/src/tokenize.js
@@ -447,7 +447,6 @@ pp.readNumber = function(startsWithDot) {
   if (!startsWithDot && this.readInt(10) === null) this.raise(start, "Invalid number")
   let octal = this.pos - start >= 2 && this.input.charCodeAt(start) === 48
   if (octal && this.strict) this.raise(start, "Invalid number")
-  if (octal && /[89]/.test(this.input.slice(start, this.pos))) octal = false
   let next = this.input.charCodeAt(this.pos)
   if (!octal && !startsWithDot && this.options.ecmaVersion >= 11 && next === 110) {
     let str = this.input.slice(start, this.pos)
@@ -456,6 +455,7 @@ pp.readNumber = function(startsWithDot) {
     if (isIdentifierStart(this.fullCharCodeAtPos())) this.raise(this.pos, "Identifier directly after number")
     return this.finishToken(tt.num, val)
   }
+  if (octal && /[89]/.test(this.input.slice(start, this.pos))) octal = false
   if (next === 46 && !octal) { // '.'
     ++this.pos
     this.readInt(10)

--- a/acorn/src/tokenize.js
+++ b/acorn/src/tokenize.js
@@ -28,7 +28,9 @@ const pp = Parser.prototype
 
 // Move to the next token
 
-pp.next = function() {
+pp.next = function(ignoreEscapeSequenceInKeyword) {
+  if (!ignoreEscapeSequenceInKeyword && this.type.keyword && this.containsEsc)
+    this.raiseRecoverable(this.start, "Escape sequence in keyword " + this.type.keyword)
   if (this.options.onToken)
     this.options.onToken(new Token(this))
 
@@ -719,7 +721,6 @@ pp.readWord = function() {
   let word = this.readWord1()
   let type = tt.name
   if (this.keywords.test(word)) {
-    if (this.containsEsc) this.raiseRecoverable(this.start, "Escape sequence in keyword " + word)
     type = keywordTypes[word]
   }
   return this.finishToken(type, word)

--- a/bin/run_test262.js
+++ b/bin/run_test262.js
@@ -10,9 +10,12 @@ const unsupportedFeatures = [
   "class-static-fields-private",
   "class-static-fields-public",
   "class-static-methods-private",
+  "coalesce-expression",
   "export-star-as-namespace-from-module",
   "import.meta",
-  "numeric-separator-literal"
+  "numeric-separator-literal",
+  "optional-chaining",
+  "top-level-await"
 ];
 
 run(

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-standard": "^3.0.1",
     "rollup": "^1.7.0",
     "rollup-plugin-buble": "^0.19.0",
-    "test262": "git+https://github.com/tc39/test262.git#de567d3aa5de4eaa11e00131d26b9fe77997dfb0",
+    "test262": "git+https://github.com/tc39/test262.git#09380a4ae412e986ea39eb7163f5a6b3e5b04bbc",
     "test262-parser-runner": "^0.5.0",
     "test262-stream": "^1.2.1",
     "unicode-12.0.0": "^0.7.9"


### PR DESCRIPTION
This PR updates `test262` to the latest and fix acorn for failed tests. (I wanted to use the updated test262 in #890 and #891.)

Failed tests are two groups:

1. tc39/test262#2253 ... BigInt literals disallow `NonOctalDecimalIntegerLiteral` (e.g. `08n`).
1. tc39/test262#2295 ... `IdentifierName` allows escaped keywords.

This PR moves the check of escaped keywords from creating tokens to consuming tokens. And this PR adds a parameter `ignoreEscapeSequenceInKeyword` to `next()` method and `parseIdent()` method uses it to ignore the error of escaped keywords.

---

This PR fixes #861 and fixes #881.

