### PR TITLE
Revamp checkLVal()

### DIFF
--- a/acorn/src/lval.js
+++ b/acorn/src/lval.js
@@ -18,6 +18,7 @@ pp.toAssignable = function(node, isBinding, refDestructuringErrors) {
 
     case "ObjectPattern":
     case "ArrayPattern":
+    case "AssignmentPattern":
     case "RestElement":
       break
 
@@ -64,9 +65,6 @@ pp.toAssignable = function(node, isBinding, refDestructuringErrors) {
       node.type = "AssignmentPattern"
       delete node.operator
       this.toAssignable(node.left, isBinding)
-      // falls through to AssignmentPattern
-
-    case "AssignmentPattern":
       break
 
     case "ParenthesizedExpression":
@@ -179,61 +177,137 @@ pp.parseMaybeDefault = function(startPos, startLoc, left) {
   return this.finishNode(node, "AssignmentPattern")
 }
 
-// Verify that a node is an lval — something that can be assigned
-// to.
-// bindingType can be either:
-// 'var' indicating that the lval creates a 'var' binding
-// 'let' indicating that the lval creates a lexical ('let' or 'const') binding
-// 'none' indicating that the binding should be checked for illegal identifiers, but not for duplicate references
+// The following three functions all verify that a node is an lvalue —
+// something that can be bound, or assigned to. In order to do so, they perform
+// a variety of checks:
+//
+// - Check that none of the bound/assigned-to identifiers are reserved words.
+// - Record name declarations for bindings in the appropriate scope.
+// - Check duplicate argument names, if checkClashes is set.
+//
+// If a complex binding pattern is encountered (e.g., object and array
+// destructuring), the entire pattern is recursively checked.
+//
+// There are three versions of checkLVal*() appropriate for different
+// circumstances:
+//
+// - checkLValSimple() shall be used if the syntactic construct supports
+//   nothing other than identifiers and member expressions. Parenthesized
+//   expressions are also correctly handled. This is generally appropriate for
+//   constructs for which the spec says
+//
+//   > It is a Syntax Error if AssignmentTargetType of [the production] is not
+//   > simple.
+//
+//   It is also appropriate for checking if an identifier is valid and not
+//   defined elsewhere, like import declarations or function/class identifiers.
+//
+//   Examples where this is used include:
+//     a += …;
+//     import a from '…';
+//   where a is the node to be checked.
+//
+// - checkLValPattern() shall be used if the syntactic construct supports
+//   anything checkLValSimple() supports, as well as object and array
+//   destructuring patterns. This is generally appropriate for constructs for
+//   which the spec says
+//
+//   > It is a Syntax Error if [the production] is neither an ObjectLiteral nor
+//   > an ArrayLiteral and AssignmentTargetType of [the production] is not
+//   > simple.
+//
+//   Examples where this is used include:
+//     (a = …);
+//     const a = …;
+//     try { … } catch (a) { … }
+//   where a is the node to be checked.
+//
+// - checkLValInnerPattern() shall be used if the syntactic construct supports
+//   anything checkLValPattern() supports, as well as default assignment
+//   patterns, rest elements, and other constructs that may appear within an
+//   object or array destructuring pattern.
+//
+//   As a special case, function parameters also use checkLValInnerPattern(),
+//   as they also support defaults and rest constructs.
+//
+// These functions deliberately support both assignment and binding constructs,
+// as the logic for both is exceedingly similar. If the node is the target of
+// an assignment, then bindingType should be set to BIND_NONE. Otherwise, it
+// should be set to the appropriate BIND_* constant, like BIND_VAR or
+// BIND_LEXICAL.
+//
+// If the function is called with a non-BIND_NONE bindingType, then
+// additionally a checkClashes object may be specified to allow checking for
+// duplicate argument names. checkClashes is ignored if the provided construct
+// is an assignment (i.e., bindingType is BIND_NONE).
 
-pp.checkLVal = function(expr, bindingType = BIND_NONE, checkClashes) {
+pp.checkLValSimple = function(expr, bindingType = BIND_NONE, checkClashes) {
+  const isBind = bindingType !== BIND_NONE
+
   switch (expr.type) {
   case "Identifier":
-    if (bindingType === BIND_LEXICAL && expr.name === "let")
-      this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name")
     if (this.strict && this.reservedWordsStrictBind.test(expr.name))
-      this.raiseRecoverable(expr.start, (bindingType ? "Binding " : "Assigning to ") + expr.name + " in strict mode")
-    if (checkClashes) {
-      if (has(checkClashes, expr.name))
-        this.raiseRecoverable(expr.start, "Argument name clash")
-      checkClashes[expr.name] = true
+      this.raiseRecoverable(expr.start, (isBind ? "Binding " : "Assigning to ") + expr.name + " in strict mode")
+    if (isBind) {
+      if (bindingType === BIND_LEXICAL && expr.name === "let")
+        this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name")
+      if (checkClashes) {
+        if (has(checkClashes, expr.name))
+          this.raiseRecoverable(expr.start, "Argument name clash")
+        checkClashes[expr.name] = true
+      }
+      if (bindingType !== BIND_OUTSIDE) this.declareName(expr.name, bindingType, expr.start)
     }
-    if (bindingType !== BIND_NONE && bindingType !== BIND_OUTSIDE) this.declareName(expr.name, bindingType, expr.start)
     break
 
   case "MemberExpression":
-    if (bindingType) this.raiseRecoverable(expr.start, "Binding member expression")
+    if (isBind) this.raiseRecoverable(expr.start, "Binding member expression")
     break
 
+  case "ParenthesizedExpression":
+    if (isBind) this.raiseRecoverable(expr.start, "Binding parenthesized expression")
+    return this.checkLValSimple(expr.expression, bindingType, checkClashes)
+
+  default:
+    this.raise(expr.start, (isBind ? "Binding" : "Assigning to") + " rvalue")
+  }
+}
+
+pp.checkLValPattern = function(expr, bindingType = BIND_NONE, checkClashes) {
+  switch (expr.type) {
   case "ObjectPattern":
-    for (let prop of expr.properties)
-      this.checkLVal(prop, bindingType, checkClashes)
-    break
-
-  case "Property":
-    // AssignmentProperty has type === "Property"
-    this.checkLVal(expr.value, bindingType, checkClashes)
+    for (let prop of expr.properties) {
+      this.checkLValInnerPattern(prop, bindingType, checkClashes)
+    }
     break
 
   case "ArrayPattern":
     for (let elem of expr.elements) {
-      if (elem) this.checkLVal(elem, bindingType, checkClashes)
+      if (elem) this.checkLValInnerPattern(elem, bindingType, checkClashes)
     }
     break
 
+  default:
+    this.checkLValSimple(expr, bindingType, checkClashes)
+  }
+}
+
+pp.checkLValInnerPattern = function(expr, bindingType = BIND_NONE, checkClashes) {
+  switch (expr.type) {
+  case "Property":
+    // AssignmentProperty has type === "Property"
+    this.checkLValInnerPattern(expr.value, bindingType, checkClashes)
+    break
+
   case "AssignmentPattern":
-    this.checkLVal(expr.left, bindingType, checkClashes)
+    this.checkLValPattern(expr.left, bindingType, checkClashes)
     break
 
   case "RestElement":
-    this.checkLVal(expr.argument, bindingType, checkClashes)
-    break
-
-  case "ParenthesizedExpression":
-    this.checkLVal(expr.expression, bindingType, checkClashes)
+    this.checkLValPattern(expr.argument, bindingType, checkClashes)
     break
 
   default:
-    this.raise(expr.start, (bindingType ? "Binding" : "Assigning to") + " rvalue")
+    this.checkLValPattern(expr, bindingType, checkClashes)
   }
 }

--- a/acorn/src/scopeflags.js
+++ b/acorn/src/scopeflags.js
@@ -14,7 +14,7 @@ export function functionFlags(async, generator) {
   return SCOPE_FUNCTION | (async ? SCOPE_ASYNC : 0) | (generator ? SCOPE_GENERATOR : 0)
 }
 
-// Used in checkLVal and declareName to determine the type of a binding
+// Used in checkLVal* and declareName to determine the type of a binding
 export const
     BIND_NONE = 0, // Not a binding
     BIND_VAR = 1, // Var-style binding

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -241,7 +241,7 @@ pp.parseForStatement = function(node) {
       } else node.await = awaitAt > -1
     }
     this.toAssignable(init, false, refDestructuringErrors)
-    this.checkLVal(init)
+    this.checkLValPattern(init)
     return this.parseForIn(node, init)
   } else {
     this.checkExpressionErrors(refDestructuringErrors, true)
@@ -342,7 +342,7 @@ pp.parseTryStatement = function(node) {
       clause.param = this.parseBindingAtom()
       let simple = clause.param.type === "Identifier"
       this.enterScope(simple ? SCOPE_SIMPLE_CATCH : 0)
-      this.checkLVal(clause.param, simple ? BIND_SIMPLE_CATCH : BIND_LEXICAL)
+      this.checkLValPattern(clause.param, simple ? BIND_SIMPLE_CATCH : BIND_LEXICAL)
       this.expect(tt.parenR)
     } else {
       if (this.options.ecmaVersion < 10) this.unexpected()
@@ -471,8 +471,6 @@ pp.parseForIn = function(node, init) {
         isForIn ? "for-in" : "for-of"
       } loop variable declaration may not have an initializer`
     )
-  } else if (init.type === "AssignmentPattern") {
-    this.raise(init.start, "Invalid left-hand side in for-loop")
   }
   node.left = init
   node.right = isForIn ? this.parseExpression() : this.parseMaybeAssign()
@@ -508,7 +506,7 @@ pp.parseVar = function(node, isFor, kind) {
 
 pp.parseVarId = function(decl, kind) {
   decl.id = this.parseBindingAtom()
-  this.checkLVal(decl.id, kind === "var" ? BIND_VAR : BIND_LEXICAL, false)
+  this.checkLValPattern(decl.id, kind === "var" ? BIND_VAR : BIND_LEXICAL, false)
 }
 
 const FUNC_STATEMENT = 1, FUNC_HANGING_STATEMENT = 2, FUNC_NULLABLE_ID = 4
@@ -534,7 +532,7 @@ pp.parseFunction = function(node, statement, allowExpressionBody, isAsync) {
       // subject to Annex B semantics (BIND_FUNCTION). Otherwise, the binding
       // mode depends on properties of the current scope (see
       // treatFunctionsAsVar).
-      this.checkLVal(node.id, (this.strict || node.generator || node.async) ? this.treatFunctionsAsVar ? BIND_VAR : BIND_LEXICAL : BIND_FUNCTION)
+      this.checkLValSimple(node.id, (this.strict || node.generator || node.async) ? this.treatFunctionsAsVar ? BIND_VAR : BIND_LEXICAL : BIND_FUNCTION)
   }
 
   let oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos
@@ -655,7 +653,7 @@ pp.parseClassId = function(node, isStatement) {
   if (this.type === tt.name) {
     node.id = this.parseIdent()
     if (isStatement)
-      this.checkLVal(node.id, BIND_LEXICAL, false)
+      this.checkLValSimple(node.id, BIND_LEXICAL, false)
   } else {
     if (isStatement === true)
       this.unexpected()
@@ -815,7 +813,7 @@ pp.parseImportSpecifiers = function() {
     // import defaultObj, { x, y as z } from '...'
     let node = this.startNode()
     node.local = this.parseIdent()
-    this.checkLVal(node.local, BIND_LEXICAL)
+    this.checkLValSimple(node.local, BIND_LEXICAL)
     nodes.push(this.finishNode(node, "ImportDefaultSpecifier"))
     if (!this.eat(tt.comma)) return nodes
   }
@@ -824,7 +822,7 @@ pp.parseImportSpecifiers = function() {
     this.next()
     this.expectContextual("as")
     node.local = this.parseIdent()
-    this.checkLVal(node.local, BIND_LEXICAL)
+    this.checkLValSimple(node.local, BIND_LEXICAL)
     nodes.push(this.finishNode(node, "ImportNamespaceSpecifier"))
     return nodes
   }
@@ -843,7 +841,7 @@ pp.parseImportSpecifiers = function() {
       this.checkUnreserved(node.imported)
       node.local = node.imported
     }
-    this.checkLVal(node.local, BIND_LEXICAL)
+    this.checkLValSimple(node.local, BIND_LEXICAL)
     nodes.push(this.finishNode(node, "ImportSpecifier"))
   }
   return nodes

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -13124,7 +13124,7 @@ testFail("for (var x = 42 of list) process(x);", "for-of loop variable declarati
 testFail("for (var x = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 8});
 testFail("for (var {x} = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
 testFail("for (var [x] = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
-testFail("var x; for (x = 42 of list) process(x);", "Invalid left-hand side in for-loop (1:12)", {ecmaVersion: 6});
+testFail("var x; for (x = 42 of list) process(x);", "Assigning to rvalue (1:12)", {ecmaVersion: 6});
 
 testFail("import foo", "Unexpected token (1:10)", {ecmaVersion: 6, sourceType: "module"});
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -19745,7 +19745,7 @@ test("for (var x in list) process(x);", {
     }
   }
 });
-testFail("var x; for (x = 0 in list) process(x);", "Invalid left-hand side in for-loop (1:12)", { ecmaVersion: 6 })
+testFail("var x; for (x = 0 in list) process(x);", "Assigning to rvalue (1:12)")
 testFail("'use strict'; for (var x = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:19)")
 testFail("for (var [x] = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
 testFail("for (var {x} = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
@@ -29432,6 +29432,7 @@ testFail("function x () { new.ta\\u0072get }", "The only valid meta property for
 testFail("class X { st\\u0061tic y() {} }", "Unexpected token (1:22)", {ecmaVersion: 6})
 
 testFail("(x=1)=2", "Parenthesized pattern (1:0)")
+testFail("(x=1)=2", "Assigning to rvalue (1:1)", {ecmaVersion: 6})
 
 test("(foo = [])[0] = 4;", {})
 


### PR DESCRIPTION
This fixes #886. I'll look into improving the error messages.

----

Currently, the same `checkLVal()` function is used for quite a few different purposes. While this arrangement has worked, pretty well one can even say, we start to see that the lack of granularity `checkLVal()` provides make the implementation of certain early errors harder than it should be. For instance, the parser for for-loops has an ad-hoc error condition for whenever the LHS is an _AssignmentPattern_. This condition would be useful in quite a few other contexts, such as in
_AssignmentExpressions_, but it would be better to look for a more general solution.

In this commit, we divide `checkLVal()` into three different functions for different usage. This allows us to accurately account for the fact that some lvalue types are allowed in certain contexts, but not others. Additionally, add extensive documentation on how the `checkLVal()` family of functions works.

The large-scale refactoring does mean that this PR would break compatibility with existing plugins, and necessitate a major version bump.

Fixes: #886