### PR TITLE
Types property added to package.json

### DIFF
--- a/acorn/package.json
+++ b/acorn/package.json
@@ -3,6 +3,7 @@
   "description": "ECMAScript parser",
   "homepage": "https://github.com/acornjs/acorn",
   "main": "dist/acorn.js",
+  "types": "dist/acorn.d.ts",
   "module": "dist/acorn.mjs",
   "version": "7.1.0",
   "engines": {"node": ">=0.4.0"},


### PR DESCRIPTION
In order for the types to be available when downloading the package, you must declare the types property in package.json