### PR TITLE
Do not reset shorthandAssign when parsing maybeAssign

### DIFF
--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -16513,4 +16513,6 @@ test("function *f2() { () => yield / 1 }", {}, {ecmaVersion: 6})
 
 test("({ a = 42, b: c.d } = e)", {}, {ecmaVersion: 6})
 
+testFail("({ a = 42, b: c = d })", "Shorthand property assignments are valid only in destructuring patterns (1:5)", {ecmaVersion: 6})
+
 test("({ __proto__: x, __proto__: y, __proto__: z }) => {}", {}, {ecmaVersion: 6})


### PR DESCRIPTION
Fixes #897 

Resetting `shorthandAssign` when parsing `maybeAssign` was introduced at https://github.com/acornjs/acorn/commit/270dee1bc1ac455a3de3a4bd6fa7a7c94cf081e3. It meant to `fix` #735, which has been recently re-fixed at https://github.com/babel/babel/pull/11031.

I port that fix here so I can port another [fix](https://github.com/babel/babel/pull/10607) that is directly addressed to #897.

