### PR TITLE
Fix some error in walk type

### DIFF
--- a/acorn-walk/dist/walk.d.ts
+++ b/acorn-walk/dist/walk.d.ts
@@ -95,15 +95,6 @@ declare module "acorn-walk" {
     node: Node,
     start: number | undefined,
     end: number | undefined,
-    type: string,
-    base?: RecursiveVisitors<TState>,
-    state?: TState
-  ): Found<TState> | undefined;
-
-  export function findNodeAt<TState>(
-    node: Node,
-    start: number | undefined,
-    end: number | undefined,
     type?: FindPredicate,
     base?: RecursiveVisitors<TState>,
     state?: TState

--- a/acorn-walk/dist/walk.d.ts
+++ b/acorn-walk/dist/walk.d.ts
@@ -94,7 +94,7 @@ declare module "acorn-walk" {
   export function findNodeAt<TState>(
     node: Node,
     start: number | undefined,
-    end: number | undefined,
+    end?: number | undefined,
     type?: FindPredicate,
     base?: RecursiveVisitors<TState>,
     state?: TState


### PR DESCRIPTION
Remove duplicate function and `end` is optional in `findNodeAround` and `findNodeAfter`