### PR TITLE
Parameterize dummy value and export `isDummy`

### DIFF
--- a/acorn-loose/README.md
+++ b/acorn-loose/README.md
@@ -60,3 +60,7 @@ take the **`LooseParser`** class exported by the module, and call its
 static `extend` method with one or more plugins to get a customized
 parser class. The class has a static `parse` method that acts like the
 top-level `parse` method.
+
+**isDummy**`(node)` takes a `Node` and returns `true` if it is a dummy node
+inserted by the parser. The function performs a simple equality check on the
+node's name.

--- a/acorn-loose/src/index.js
+++ b/acorn-loose/src/index.js
@@ -36,6 +36,7 @@ import "./statement"
 import "./expression"
 
 export {LooseParser} from "./state"
+export {isDummy} from "./parseutil"
 
 defaultOptions.tabSize = 4
 

--- a/acorn-loose/src/parseutil.js
+++ b/acorn-loose/src/parseutil.js
@@ -1,1 +1,3 @@
-export function isDummy(node) { return node.name === "✖" }
+export const dummyValue = "✖"
+
+export function isDummy(node) { return node.name === dummyValue }

--- a/acorn-loose/src/state.js
+++ b/acorn-loose/src/state.js
@@ -1,4 +1,5 @@
 import {Parser, SourceLocation, tokTypes as tt, Node, lineBreak, isNewLine} from "acorn"
+import {dummyValue} from "./parseutil"
 
 function noop() {}
 
@@ -63,13 +64,13 @@ export class LooseParser {
 
   dummyIdent() {
     let dummy = this.dummyNode("Identifier")
-    dummy.name = "✖"
+    dummy.name = dummyValue
     return dummy
   }
 
   dummyString() {
     let dummy = this.dummyNode("Literal")
-    dummy.value = dummy.raw = "✖"
+    dummy.value = dummy.raw = dummyValue
     return dummy
   }
 

--- a/acorn-loose/src/tokenize.js
+++ b/acorn-loose/src/tokenize.js
@@ -1,5 +1,6 @@
 import {tokTypes as tt, Token, isNewLine, SourceLocation, getLineInfo, lineBreakG} from "acorn"
 import {LooseParser} from "./state"
+import {dummyValue} from "./parseutil"
 
 const lp = LooseParser.prototype
 
@@ -73,7 +74,7 @@ lp.readToken = function() {
         throw e
       }
       this.resetTo(pos)
-      if (replace === true) replace = {start: pos, end: pos, type: tt.name, value: "✖"}
+      if (replace === true) replace = {start: pos, end: pos, type: tt.name, value: dummyValue}
       if (replace) {
         if (this.options.locations)
           replace.loc = new SourceLocation(


### PR DESCRIPTION
This PR parameterizes the dummy value used in `acorn-loose` and exports the `isDummy` function. 

I want to be able to check for dummy nodes in the AST without hard-coding the dummy value in my code base.