### PR TITLE
fix: check potentialArrowAt in maybeAsyncArrow

### DIFF
--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -262,7 +262,8 @@ pp.parseExprSubscripts = function(refDestructuringErrors) {
 
 pp.parseSubscripts = function(base, startPos, startLoc, noCalls) {
   let maybeAsyncArrow = this.options.ecmaVersion >= 8 && base.type === "Identifier" && base.name === "async" &&
-      this.lastTokEnd === base.end && !this.canInsertSemicolon() && this.input.slice(base.start, base.end) === "async"
+      this.lastTokEnd === base.end && !this.canInsertSemicolon() && base.end - base.start === 5 &&
+      this.potentialArrowAt === base.start
   while (true) {
     let element = this.parseSubscript(base, startPos, startLoc, noCalls, maybeAsyncArrow)
     if (element === base || element.type === "ArrowFunctionExpression") return element

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -3525,3 +3525,5 @@ test("({ async delete() {} })", {}, {ecmaVersion: 8})
 testFail("abc: async function a() {}", "Unexpected token (1:5)", {ecmaVersion: 8})
 
 test("(async() => { await 4 ** 2 })()", {}, {ecmaVersion: 8})
+
+testFail("4 + async() => 2", "Unexpected token (1:12)", {ecmaVersion: 8, loose: false})


### PR DESCRIPTION
Backported from https://github.com/babel/babel/pull/11284

Fixes #914 