### PR TITLE
make test262 success on Windows

### DIFF
--- a/bin/run_test262.js
+++ b/bin/run_test262.js
@@ -21,6 +21,9 @@ run(
   {
     testsDirectory: path.dirname(require.resolve("test262/package.json")),
     skip: test => (test.attrs.features && unsupportedFeatures.some(f => test.attrs.features.includes(f))),
-    whitelist: fs.readFileSync("./bin/test262.whitelist", "utf8").split("\n").filter(v => v)
+    whitelist: fs.readFileSync("./bin/test262.whitelist", "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map(filename => path.sep !== "/" ? filename.split("/").join(path.sep) : filename)
   }
 )


### PR DESCRIPTION
This PR fixes the `test:test262` script to be able to run on Windows, too.

Currently, if I run the script on Windows, the following error appears:

<details>

```
> npm run -s test:test262
Testing complete.
Summary:
 ✔ 58151 valid programs parsed without error
 ✔ 5278 invalid programs produced a parsing error
 ✔ 0 invalid programs did not produce a parsing error (and allowed by the whitelist file)
 ✔ 0 valid programs produced a parsing error (and allowed by the whitelist file)
 ✔ 9617 programs were skipped

 ✘ 10 invalid programs did not produce a parsing error (without a corresponding entry in the whitelist file)
 ✘ 10 non-existent programs specified in the whitelist file

Details:
   language\literals\regexp\named-groups\invalid-non-id-continue-groupspecifier.js (default)
   language\literals\regexp\named-groups\invalid-non-id-continue-groupspecifier.js (strict mode)
   language\literals\regexp\named-groups\invalid-non-id-start-groupspecifier-3.js (default)
   language\literals\regexp\named-groups\invalid-non-id-start-groupspecifier-3.js (strict mode)
   language\literals\regexp\named-groups\invalid-non-id-start-groupspecifier-6.js (default)
   language\literals\regexp\named-groups\invalid-non-id-start-groupspecifier-6.js (strict mode)
   language\literals\regexp\named-groups\invalid-u-escape-in-groupspecifier-2.js (default)
   language\literals\regexp\named-groups\invalid-u-escape-in-groupspecifier.js (default)
   language\literals\regexp\named-groups\invalid-u-escape-in-groupspecifier.js (strict mode)
   10 non-existent programs specified in the whitelist file:
   language/literals/regexp/named-groups/invalid-non-id-continue-groupspecifier.js (default)
   language/literals/regexp/named-groups/invalid-non-id-continue-groupspecifier.js (strict mode)
   language/literals/regexp/named-groups/invalid-non-id-start-groupspecifier-3.js (default)
   language/literals/regexp/named-groups/invalid-non-id-start-groupspecifier-3.js (strict mode)
   language/literals/regexp/named-groups/invalid-non-id-start-groupspecifier-6.js (default)
   language/literals/regexp/named-groups/invalid-non-id-start-groupspecifier-6.js (strict mode)
   language/literals/regexp/named-groups/invalid-u-escape-in-groupspecifier.js (default)
   language/literals/regexp/named-groups/invalid-u-escape-in-groupspecifier.js (strict mode)
   language/literals/regexp/named-groups/invalid-u-escape-in-groupspecifier-2.js (default)
   language/literals/regexp/named-groups/invalid-u-escape-in-groupspecifier-2.js (strict mode)
```

</details>

After this PR, the `test:test262` script fixes the path separator before passing those to the runner.