### PR TITLE
Add "MIT License" at the top of acorn License file

### DIFF
--- a/acorn/LICENSE
+++ b/acorn/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Copyright (C) 2012-2018 by various contributors (see AUTHORS)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy


### PR DESCRIPTION
Add a first line that specifies the license type "MIT License" this makes it more clear to developers which license is being used and can help them more easily determine if `acorn` is a package that they are okay to use in their software. [This is also the default for an MIT license for a repository when adding one in GitHub](https://github.com/joekrump/acorn/community/license/new?branch=master&template=mit).