### PR TITLE
Major release 8.0.0

### DIFF
--- a/acorn-loose/README.md
+++ b/acorn-loose/README.md
@@ -52,7 +52,7 @@ on the `acorn` package, because it uses the same tokenizer.
 
 ```javascript
 var acornLoose = require("acorn-loose");
-console.log(acornLoose.parse("1 / * 4 )[2]"));
+console.log(acornLoose.parse("1 / * 4 )[2]", {ecmaVersion: 2020}));
 ```
 
 Like the regular parser, the loose parser supports plugins. You can

--- a/acorn-loose/package.json
+++ b/acorn-loose/package.json
@@ -4,6 +4,10 @@
   "homepage": "https://github.com/acornjs/acorn",
   "main": "dist/acorn-loose.js",
   "module": "dist/acorn-loose.mjs",
+  "exports": {
+    "import": "./dist/acorn-loose.mjs",
+    "require": "./dist/acorn-loose.js"
+  },
   "version": "7.1.0",
   "engines": {"node": ">=0.4.0"},
   "dependencies": {

--- a/acorn-walk/package.json
+++ b/acorn-walk/package.json
@@ -5,6 +5,10 @@
   "main": "dist/walk.js",
   "types": "dist/walk.d.ts",
   "module": "dist/walk.mjs",
+  "exports": {
+    "import": "./dist/walk.mjs",
+    "require": "./dist/walk.js"
+  },
   "version": "7.2.0",
   "engines": {"node": ">=0.4.0"},
   "maintainers": [

--- a/acorn/README.md
+++ b/acorn/README.md
@@ -32,14 +32,14 @@ npm install
 ## Interface
 
 **parse**`(input, options)` is the main interface to the library. The
-`input` parameter is a string, `options` can be undefined or an object
-setting some of the options listed below. The return value will be an
-abstract syntax tree object as specified by the [ESTree
+`input` parameter is a string, `options` must be an object setting
+some of the options listed below. The return value will be an abstract
+syntax tree object as specified by the [ESTree
 spec](https://github.com/estree/estree).
 
 ```javascript
 let acorn = require("acorn");
-console.log(acorn.parse("1 + 1"));
+console.log(acorn.parse("1 + 1", {ecmaVersion: 2020}));
 ```
 
 When encountering a syntax error, the parser will raise a
@@ -48,18 +48,19 @@ have a `pos` property that indicates the string offset at which the
 error occurred, and a `loc` object that contains a `{line, column}`
 object referring to that same position.
 
-Options can be provided by passing a second argument, which should be
-an object containing any of these fields:
+Options are provided by in a second argument, which should be an
+object containing any of these fields (only `ecmaVersion` is
+required):
 
 - **ecmaVersion**: Indicates the ECMAScript version to parse. Must be
-  either 3, 5, 6 (2015), 7 (2016), 8 (2017), 9 (2018), 10 (2019) or 11
-  (2020, partial support). This influences support for strict mode,
-  the set of reserved words, and support for new syntax features.
-  Default is 10.
+  either 3, 5, 6 (or 2015), 7 (2016), 8 (2017), 9 (2018), 10 (2019),
+  11 (2020), or 12 (2021, partial support), or `"latest"` (the latest
+  the library supports). This influences support for strict mode, the
+  set of reserved words, and support for new syntax features.
 
   **NOTE**: Only 'stage 4' (finalized) ECMAScript features are being
-  implemented by Acorn. Other proposed new features can be implemented
-  through plugins.
+  implemented by Acorn. Other proposed new features must be
+  implemented through plugins.
 
 - **sourceType**: Indicate the mode the code should be parsed in. Can be
   either `"script"` or `"module"`. This influences global strict mode
@@ -224,7 +225,7 @@ you can use its static `extend` method.
 var acorn = require("acorn");
 var jsx = require("acorn-jsx");
 var JSXParser = acorn.Parser.extend(jsx());
-JSXParser.parse("foo(<bar/>)");
+JSXParser.parse("foo(<bar/>)", {ecmaVersion: 2020});
 ```
 
 The `extend` method takes any number of plugin values, and returns a

--- a/acorn/package.json
+++ b/acorn/package.json
@@ -5,6 +5,10 @@
   "main": "dist/acorn.js",
   "types": "dist/acorn.d.ts",
   "module": "dist/acorn.mjs",
+  "exports": {
+    "import": "./dist/acorn.mjs",
+    "require": "./dist/acorn.js"
+  },
   "version": "7.4.0",
   "engines": {"node": ">=0.4.0"},
   "maintainers": [

--- a/acorn/src/.eslintrc
+++ b/acorn/src/.eslintrc
@@ -12,6 +12,7 @@
         "new-parens": "off",
         "no-case-declarations": "off",
         "no-cond-assign": "off",
+        "no-console": ["error", { allow: ["warn", "error"] }],
         "no-fallthrough": "off",
         "no-labels": "off",
         "no-mixed-operators": "off",

--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -624,7 +624,7 @@ pp.parseNew = function() {
       this.raiseRecoverable(node.property.start, "The only valid meta property for new is 'new.target'")
     if (containsEsc)
       this.raiseRecoverable(node.start, "'new.target' must not contain escaped characters")
-    if (!this.inNonArrowFunction())
+    if (!this.inNonArrowFunction)
       this.raiseRecoverable(node.start, "'new.target' can only be used in functions")
     return this.finishNode(node, "MetaProperty")
   }

--- a/acorn/src/lval.js
+++ b/acorn/src/lval.js
@@ -18,6 +18,7 @@ pp.toAssignable = function(node, isBinding, refDestructuringErrors) {
 
     case "ObjectPattern":
     case "ArrayPattern":
+    case "AssignmentPattern":
     case "RestElement":
       break
 
@@ -64,9 +65,6 @@ pp.toAssignable = function(node, isBinding, refDestructuringErrors) {
       node.type = "AssignmentPattern"
       delete node.operator
       this.toAssignable(node.left, isBinding)
-      // falls through to AssignmentPattern
-
-    case "AssignmentPattern":
       break
 
     case "ParenthesizedExpression":
@@ -183,26 +181,87 @@ pp.parseMaybeDefault = function(startPos, startLoc, left) {
   return this.finishNode(node, "AssignmentPattern")
 }
 
-// Verify that a node is an lval — something that can be assigned
-// to.
-// bindingType can be either:
-// 'var' indicating that the lval creates a 'var' binding
-// 'let' indicating that the lval creates a lexical ('let' or 'const') binding
-// 'none' indicating that the binding should be checked for illegal identifiers, but not for duplicate references
+// The following three functions all verify that a node is an lvalue —
+// something that can be bound, or assigned to. In order to do so, they perform
+// a variety of checks:
+//
+// - Check that none of the bound/assigned-to identifiers are reserved words.
+// - Record name declarations for bindings in the appropriate scope.
+// - Check duplicate argument names, if checkClashes is set.
+//
+// If a complex binding pattern is encountered (e.g., object and array
+// destructuring), the entire pattern is recursively checked.
+//
+// There are three versions of checkLVal*() appropriate for different
+// circumstances:
+//
+// - checkLValSimple() shall be used if the syntactic construct supports
+//   nothing other than identifiers and member expressions. Parenthesized
+//   expressions are also correctly handled. This is generally appropriate for
+//   constructs for which the spec says
+//
+//   > It is a Syntax Error if AssignmentTargetType of [the production] is not
+//   > simple.
+//
+//   It is also appropriate for checking if an identifier is valid and not
+//   defined elsewhere, like import declarations or function/class identifiers.
+//
+//   Examples where this is used include:
+//     a += …;
+//     import a from '…';
+//   where a is the node to be checked.
+//
+// - checkLValPattern() shall be used if the syntactic construct supports
+//   anything checkLValSimple() supports, as well as object and array
+//   destructuring patterns. This is generally appropriate for constructs for
+//   which the spec says
+//
+//   > It is a Syntax Error if [the production] is neither an ObjectLiteral nor
+//   > an ArrayLiteral and AssignmentTargetType of [the production] is not
+//   > simple.
+//
+//   Examples where this is used include:
+//     (a = …);
+//     const a = …;
+//     try { … } catch (a) { … }
+//   where a is the node to be checked.
+//
+// - checkLValInnerPattern() shall be used if the syntactic construct supports
+//   anything checkLValPattern() supports, as well as default assignment
+//   patterns, rest elements, and other constructs that may appear within an
+//   object or array destructuring pattern.
+//
+//   As a special case, function parameters also use checkLValInnerPattern(),
+//   as they also support defaults and rest constructs.
+//
+// These functions deliberately support both assignment and binding constructs,
+// as the logic for both is exceedingly similar. If the node is the target of
+// an assignment, then bindingType should be set to BIND_NONE. Otherwise, it
+// should be set to the appropriate BIND_* constant, like BIND_VAR or
+// BIND_LEXICAL.
+//
+// If the function is called with a non-BIND_NONE bindingType, then
+// additionally a checkClashes object may be specified to allow checking for
+// duplicate argument names. checkClashes is ignored if the provided construct
+// is an assignment (i.e., bindingType is BIND_NONE).
 
-pp.checkLVal = function(expr, bindingType = BIND_NONE, checkClashes) {
+pp.checkLValSimple = function(expr, bindingType = BIND_NONE, checkClashes) {
+  const isBind = bindingType !== BIND_NONE
+
   switch (expr.type) {
   case "Identifier":
-    if (bindingType === BIND_LEXICAL && expr.name === "let")
-      this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name")
     if (this.strict && this.reservedWordsStrictBind.test(expr.name))
-      this.raiseRecoverable(expr.start, (bindingType ? "Binding " : "Assigning to ") + expr.name + " in strict mode")
-    if (checkClashes) {
-      if (has(checkClashes, expr.name))
-        this.raiseRecoverable(expr.start, "Argument name clash")
-      checkClashes[expr.name] = true
+      this.raiseRecoverable(expr.start, (isBind ? "Binding " : "Assigning to ") + expr.name + " in strict mode")
+    if (isBind) {
+      if (bindingType === BIND_LEXICAL && expr.name === "let")
+        this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name")
+      if (checkClashes) {
+        if (has(checkClashes, expr.name))
+          this.raiseRecoverable(expr.start, "Argument name clash")
+        checkClashes[expr.name] = true
+      }
+      if (bindingType !== BIND_OUTSIDE) this.declareName(expr.name, bindingType, expr.start)
     }
-    if (bindingType !== BIND_NONE && bindingType !== BIND_OUTSIDE) this.declareName(expr.name, bindingType, expr.start)
     break
 
   case "ChainExpression":
@@ -210,38 +269,53 @@ pp.checkLVal = function(expr, bindingType = BIND_NONE, checkClashes) {
     break
 
   case "MemberExpression":
-    if (bindingType) this.raiseRecoverable(expr.start, "Binding member expression")
+    if (isBind) this.raiseRecoverable(expr.start, "Binding member expression")
     break
 
+  case "ParenthesizedExpression":
+    if (isBind) this.raiseRecoverable(expr.start, "Binding parenthesized expression")
+    return this.checkLValSimple(expr.expression, bindingType, checkClashes)
+
+  default:
+    this.raise(expr.start, (isBind ? "Binding" : "Assigning to") + " rvalue")
+  }
+}
+
+pp.checkLValPattern = function(expr, bindingType = BIND_NONE, checkClashes) {
+  switch (expr.type) {
   case "ObjectPattern":
-    for (let prop of expr.properties)
-      this.checkLVal(prop, bindingType, checkClashes)
-    break
-
-  case "Property":
-    // AssignmentProperty has type === "Property"
-    this.checkLVal(expr.value, bindingType, checkClashes)
+    for (let prop of expr.properties) {
+      this.checkLValInnerPattern(prop, bindingType, checkClashes)
+    }
     break
 
   case "ArrayPattern":
     for (let elem of expr.elements) {
-      if (elem) this.checkLVal(elem, bindingType, checkClashes)
+      if (elem) this.checkLValInnerPattern(elem, bindingType, checkClashes)
     }
     break
 
+  default:
+    this.checkLValSimple(expr, bindingType, checkClashes)
+  }
+}
+
+pp.checkLValInnerPattern = function(expr, bindingType = BIND_NONE, checkClashes) {
+  switch (expr.type) {
+  case "Property":
+    // AssignmentProperty has type === "Property"
+    this.checkLValInnerPattern(expr.value, bindingType, checkClashes)
+    break
+
   case "AssignmentPattern":
-    this.checkLVal(expr.left, bindingType, checkClashes)
+    this.checkLValPattern(expr.left, bindingType, checkClashes)
     break
 
   case "RestElement":
-    this.checkLVal(expr.argument, bindingType, checkClashes)
-    break
-
-  case "ParenthesizedExpression":
-    this.checkLVal(expr.expression, bindingType, checkClashes)
+    this.checkLValPattern(expr.argument, bindingType, checkClashes)
     break
 
   default:
-    this.raise(expr.start, (bindingType ? "Binding" : "Assigning to") + " rvalue")
+    this.checkLValPattern(expr, bindingType, checkClashes)
   }
 }

--- a/acorn/src/options.js
+++ b/acorn/src/options.js
@@ -1,16 +1,16 @@
 import {has, isArray} from "./util"
 import {SourceLocation} from "./locutil"
 
-// A second optional argument can be given to further configure
-// the parser process. These options are recognized:
+// A second argument must be given to configure the parser process.
+// These options are recognized (only `ecmaVersion` is required):
 
 export const defaultOptions = {
   // `ecmaVersion` indicates the ECMAScript version to parse. Must be
-  // either 3, 5, 6 (2015), 7 (2016), 8 (2017), 9 (2018), or 10
-  // (2019). This influences support for strict mode, the set of
-  // reserved words, and support for new syntax features. The default
-  // is 10.
-  ecmaVersion: 10,
+  // either 3, 5, 6 (or 2015), 7 (2016), 8 (2017), 9 (2018), 10
+  // (2019), 11 (2020), 12 (2021), or `"latest"` (the latest version
+  // the library supports). This influences support for strict mode,
+  // the set of reserved words, and support for new syntax features.
+  ecmaVersion: null,
   // `sourceType` indicates the mode the code should be parsed in.
   // Can be either `"script"` or `"module"`. This influences global
   // strict mode and parsing of `import` and `export` declarations.
@@ -91,14 +91,25 @@ export const defaultOptions = {
 
 // Interpret and default an options object
 
+let warnedAboutEcmaVersion = false
+
 export function getOptions(opts) {
   let options = {}
 
   for (let opt in defaultOptions)
     options[opt] = opts && has(opts, opt) ? opts[opt] : defaultOptions[opt]
 
-  if (options.ecmaVersion >= 2015)
+  if (options.ecmaVersion === "latest") {
+    options.ecmaVersion = 1e8
+  } else if (options.ecmaVersion == null) {
+    if (!warnedAboutEcmaVersion && typeof console === "object" && console.warn) {
+      warnedAboutEcmaVersion = true
+      console.warn("Since Acorn 8.0.0, options.ecmaVersion is required.\nDefaulting to 2020, but this will stop working in the future.")
+    }
+    options.ecmaVersion = 11
+  } else if (options.ecmaVersion >= 2015) {
     options.ecmaVersion -= 2009
+  }
 
   if (options.allowReserved == null)
     options.allowReserved = options.ecmaVersion < 5

--- a/acorn/src/scopeflags.js
+++ b/acorn/src/scopeflags.js
@@ -14,7 +14,7 @@ export function functionFlags(async, generator) {
   return SCOPE_FUNCTION | (async ? SCOPE_ASYNC : 0) | (generator ? SCOPE_GENERATOR : 0)
 }
 
-// Used in checkLVal and declareName to determine the type of a binding
+// Used in checkLVal* and declareName to determine the type of a binding
 export const
     BIND_NONE = 0, // Not a binding
     BIND_VAR = 1, // Var-style binding

--- a/acorn/src/state.js
+++ b/acorn/src/state.js
@@ -98,9 +98,7 @@ export class Parser {
   get allowSuper() { return (this.currentThisScope().flags & SCOPE_SUPER) > 0 }
   get allowDirectSuper() { return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER) > 0 }
   get treatFunctionsAsVar() { return this.treatFunctionsAsVarInScope(this.currentScope()) }
-
-  // Switch to a getter for 7.0.0.
-  inNonArrowFunction() { return (this.currentThisScope().flags & SCOPE_FUNCTION) > 0 }
+  get inNonArrowFunction() { return (this.currentThisScope().flags & SCOPE_FUNCTION) > 0 }
 
   static extend(...plugins) {
     let cls = this

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -13124,7 +13124,7 @@ testFail("for (var x = 42 of list) process(x);", "for-of loop variable declarati
 testFail("for (var x = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 8});
 testFail("for (var {x} = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
 testFail("for (var [x] = 42 of list) process(x);", "for-of loop variable declaration may not have an initializer (1:5)", {ecmaVersion: 6});
-testFail("var x; for (x = 42 of list) process(x);", "Invalid left-hand side in for-loop (1:12)", {ecmaVersion: 6});
+testFail("var x; for (x = 42 of list) process(x);", "Assigning to rvalue (1:12)", {ecmaVersion: 6});
 
 testFail("import foo", "Unexpected token (1:10)", {ecmaVersion: 6, sourceType: "module"});
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -19745,7 +19745,7 @@ test("for (var x in list) process(x);", {
     }
   }
 });
-testFail("var x; for (x = 0 in list) process(x);", "Invalid left-hand side in for-loop (1:12)", { ecmaVersion: 6 })
+testFail("var x; for (x = 0 in list) process(x);", "Assigning to rvalue (1:12)")
 testFail("'use strict'; for (var x = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:19)")
 testFail("for (var [x] = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
 testFail("for (var {x} = 0 in list) process(x);", "for-in loop variable declaration may not have an initializer (1:5)", { ecmaVersion: 6 })
@@ -29432,6 +29432,7 @@ testFail("function x () { new.ta\\u0072get }", "'new.target' must not contain es
 testFail("class X { st\\u0061tic y() {} }", "Unexpected token (1:22)", {ecmaVersion: 6})
 
 testFail("(x=1)=2", "Parenthesized pattern (1:0)")
+testFail("(x=1)=2", "Assigning to rvalue (1:1)", {ecmaVersion: 6})
 
 test("(foo = [])[0] = 4;", {})
 


### PR DESCRIPTION
This does three things:

 - Merge [#893](https://github.com/acornjs/acorn/pull/893) (resolving a minor merge conflict)

 - Add `exports` sections to the package.json files so that node 13+ can load them as ES modules

 - Add a deprecation warning when no `ecmaVersion` option is specified. Add a `"latest"` value for that option that allows everything we support to be parsed.

I'm going to let this sit here for review and comment for a bit, and if everything looks okay, merge it and release 8.0.0.

cc @RReverser @adrianheine 