### PR TITLE
fix: acornLoose set defaultOptions to the actual default of the options parameter

### DIFF
--- a/acorn-loose/src/index.js
+++ b/acorn-loose/src/index.js
@@ -40,6 +40,6 @@ export {isDummy} from "./parseutil"
 
 defaultOptions.tabSize = 4
 
-export function parse(input, options) {
+export function parse(input, options = defaultOptions) {
   return LooseParser.parse(input, options)
 }


### PR DESCRIPTION
I ran into an error, that tabSize was undefined which is used [here](https://github.com/acornjs/acorn/blob/master/acorn-loose/src/state.js#L130) when no options were provided for the parse function.
Noticing that the defaultOptions are imported and extended but not used (if i am not overlooking something completely obvious right now), I am wondering why no one had run into this problem bevor.
