### PR TITLE
fix: the sourcemap configuration in the rollup configuration

### DIFF
--- a/acorn-loose/rollup.config.js
+++ b/acorn-loose/rollup.config.js
@@ -7,14 +7,14 @@ export default {
       file: "acorn-loose/dist/acorn-loose.js",
       format: "umd",
       name: "acorn.loose",
-      sourceMap: true,
+      sourcemap: true,
       external: ["acorn"],
       globals: {acorn: "acorn"}
     },
     {
       file: "acorn-loose/dist/acorn-loose.mjs",
       format: "es",
-      sourceMap: true,
+      sourcemap: true,
       external: ["acorn"],
       globals: {acorn: "acorn"}
     }

--- a/acorn-walk/rollup.config.js
+++ b/acorn-walk/rollup.config.js
@@ -7,12 +7,12 @@ export default {
       file: "acorn-walk/dist/walk.js",
       format: "umd",
       name: "acorn.walk",
-      sourceMap: true
+      sourcemap: true
     },
     {
       file: "acorn-walk/dist/walk.mjs",
       format: "es",
-      sourceMap: true
+      sourcemap: true
     }
   ],
   plugins: [

--- a/acorn/rollup.config.js
+++ b/acorn/rollup.config.js
@@ -7,12 +7,12 @@ export default {
       file: "acorn/dist/acorn.js",
       format: "umd",
       name: "acorn",
-      sourceMap: true
+      sourcemap: true
     },
     {
       file: "acorn/dist/acorn.mjs",
       format: "es",
-      sourceMap: true
+      sourcemap: true
     }
   ],
   plugins: [


### PR DESCRIPTION
`sourcemap` should be lowercase, otherwise it won't work.

[https://rollupjs.org/guide/en/#outputsourcemap](https://rollupjs.org/guide/en/#outputsourcemap)