### PR TITLE
support import when sourceType=module

### DIFF
--- a/acorn-loose/src/expression.js
+++ b/acorn-loose/src/expression.js
@@ -319,7 +319,7 @@ lp.parseExprAtom = function() {
     return this.parseTemplate()
 
   case tt._import:
-    if (this.options.ecmaVersion >= 11) {
+    if (this.options.ecmaVersion >= 11 || this.options.sourceType === "module") {
       return this.parseExprImport()
     } else {
       return this.dummyIdent()

--- a/acorn-loose/src/statement.js
+++ b/acorn-loose/src/statement.js
@@ -176,7 +176,7 @@ lp.parseStatement = function() {
     return this.parseClass(true)
 
   case tt._import:
-    if (this.options.ecmaVersion > 10) {
+    if (this.options.ecmaVersion > 10 || this.options.sourceType === "module") {
       const nextType = this.lookAhead(1).type
       if (nextType === tt.parenL || nextType === tt.dot) {
         node.expression = this.parseExpression()

--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -453,7 +453,7 @@ pp.parseExprAtom = function(refDestructuringErrors) {
     return this.parseTemplate()
 
   case tt._import:
-    if (this.options.ecmaVersion >= 11) {
+    if (this.options.ecmaVersion >= 11 || this.options.sourceType === "module") {
       return this.parseExprImport()
     } else {
       return this.unexpected()

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -118,7 +118,7 @@ pp.parseStatement = function(context, topLevel, exports) {
   case tt.semi: return this.parseEmptyStatement(node)
   case tt._export:
   case tt._import:
-    if (this.options.ecmaVersion > 10 && starttype === tt._import) {
+    if ((this.options.ecmaVersion > 10 || this.options.sourceType === "module") && starttype === tt._import) {
       skipWhiteSpace.lastIndex = this.pos
       let skip = skipWhiteSpace.exec(this.input)
       let next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next)

--- a/test/tests-dynamic-import.js
+++ b/test/tests-dynamic-import.js
@@ -35,6 +35,35 @@ test(
   { ecmaVersion: 11 }
 );
 
+test(
+  "import('dynamicImport.js')",
+  {
+    type: 'Program',
+    start: 0,
+    end: 26,
+    body: [
+      {
+        type: 'ExpressionStatement',
+        start: 0,
+        end: 26,
+        expression: {
+          type: 'ImportExpression',
+          start: 0,
+          end: 26,
+          source: {
+            type: 'Literal',
+            start: 7,
+            end: 25,
+            value: 'dynamicImport.js',
+            raw: "'dynamicImport.js'"
+          }
+        }
+      }
+    ],
+  },
+  { ecmaVersion: 5,  sourceType: 'module' }
+);
+
 // Assignment is OK.
 test(
   "import(a = 'dynamicImport.js')",
@@ -212,12 +241,6 @@ testFail('function failsParse() { return import.then(); }', 'The only valid meta
 testFail("var dynImport = import; dynImport('http');", 'Unexpected token (1:22)', {
   ecmaVersion: 11,
   loose: false
-});
-
-testFail("import('test.js')", 'Unexpected token (1:6)', {
-  ecmaVersion: 10,
-  loose: false,
-  sourceType: 'module'
 });
 
 testFail("import()", 'Unexpected token (1:7)', {

--- a/test/tests-import-meta.js
+++ b/test/tests-import-meta.js
@@ -87,7 +87,6 @@ test(
   { ecmaVersion: 11, sourceType: "module" }
 );
 
-testFail("import.meta", "Unexpected token (1:6)", { ecmaVersion: 10, sourceType: "module" });
 testFail("import.meta", "Cannot use 'import.meta' outside a module (1:0)", { ecmaVersion: 11, sourceType: "script" });
 testFail("import['meta']", "Unexpected token (1:6)", { ecmaVersion: 11, sourceType: "module" });
 testFail("a = import['meta']", "Unexpected token (1:10)", { ecmaVersion: 11, sourceType: "module" });

--- a/test/tests.js
+++ b/test/tests.js
@@ -31,11 +31,6 @@ test("import ''", {
   sourceType: "module"
 });
 
-testFail("import('')", "Unexpected token (1:6)", {
-  ecmaVersion: 5,
-  sourceType: "module"
-});
-
 test("new Object", {
   type: "Program",
   start: 0,


### PR DESCRIPTION
when sourceType=module, acorn should allow dynamic import and import.meta(bundlers such as webpack will handle them)