### PR TITLE
patch[walker] [loose parser] [acorn] patch: fix "exports" for node v12.16.0,v13.0-v13.6

### DIFF
--- a/acorn-loose/package.json
+++ b/acorn-loose/package.json
@@ -5,8 +5,15 @@
   "main": "dist/acorn-loose.js",
   "module": "dist/acorn-loose.mjs",
   "exports": {
-    "import": "./dist/acorn-loose.mjs",
-    "require": "./dist/acorn-loose.js"
+    ".": [
+      {
+        "import": "./dist/acorn-loose.mjs",
+        "require": "./dist/acorn-loose.js",
+        "default": "./dist/acorn-loose.js"
+      },
+      "./dist/acorn-loose.js"
+    ],
+    "./package.json": "./package.json"
   },
   "version": "8.0.1",
   "engines": {"node": ">=0.4.0"},

--- a/acorn-walk/package.json
+++ b/acorn-walk/package.json
@@ -6,8 +6,15 @@
   "types": "dist/walk.d.ts",
   "module": "dist/walk.mjs",
   "exports": {
-    "import": "./dist/walk.mjs",
-    "require": "./dist/walk.js"
+    ".": [
+      {
+        "import": "./dist/walk.mjs",
+        "require": "./dist/walk.js",
+        "default": "./dist/walk.js"
+      },
+      "./dist/walk.js"
+    ],
+    "./package.json": "./package.json"
   },
   "version": "8.0.1",
   "engines": {"node": ">=0.4.0"},

--- a/acorn/package.json
+++ b/acorn/package.json
@@ -6,8 +6,15 @@
   "types": "dist/acorn.d.ts",
   "module": "dist/acorn.mjs",
   "exports": {
-    "import": "./dist/acorn.mjs",
-    "require": "./dist/acorn.js"
+    ".": [
+      {
+        "import": "./dist/acorn.mjs",
+        "require": "./dist/acorn.js",
+        "default": "./dist/acorn.js"
+      },
+      "./dist/acorn.js"
+    ],
+    "./package.json": "./package.json"
   },
   "version": "8.0.4",
   "engines": {"node": ">=0.4.0"},


### PR DESCRIPTION
Fixes #1007

I went ahead and fixed all three packages, and also added package.json so tooling can reliably locate it.