### PR TITLE
Update authors list, use .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,4 @@
+Adrian Heine <mail@adrianheine.de>
+Alistair Braidwood <alistair_braidwood@yahoo.co.uk>
+Forbes Lindesay <forbes@lindesay.co.uk>
+Rich Harris <richard.a.harris@gmail.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -41,7 +41,9 @@ Joel Kemp
 Johannes Herr
 John-David Dalton
 Jordan Gensler
+Jordan Harband
 Jordan Klassen
+Julian Wyzykowski
 Jürg Lehni
 Kai Cataldo
 keeyipchan
@@ -75,11 +77,11 @@ piotr
 PlNG
 Praveen N
 Prayag Verma
-ReadmeCritic
 r-e-d
+ReadmeCritic
 Renée Kooi
-Richard Gibson
 Rich Harris
+Richard Gibson
 Sebastian McKenzie
 Shahar Soel
 Sheel Bedi
@@ -87,8 +89,8 @@ Simen Bekkhus
 susiwen
 susiwen8
 Teddy Katz
-Timothy Gu
 Tim van der Lippe
+Timothy Gu
 Tony Ross
 Toru Nagashima
 tuesmiddt
@@ -96,4 +98,5 @@ Victor Homyakov
 Vladislav Tupikin
 Wexpo Lyu
 zsjforcn
+星灵
 龙腾道

--- a/bin/update_authors.sh
+++ b/bin/update_authors.sh
@@ -1,3 +1,3 @@
 echo "List of Acorn contributors. Updated before every release." > AUTHORS
 echo >> AUTHORS
-git log --format='%aN' | grep -v 'Adrian Heine né Lang' | grep -v abraidwood | grep -v Rich-Harris | grep -v ForbesLindesay | sort -u >> AUTHORS
+git log --format='%aN' | sort -uf >> AUTHORS


### PR DESCRIPTION
Use a git standard `.mailmap` file for removing duplicates and choosing which names to use for authors that used different display names on different commits.

This means `git log` and `git show` naturally pick it up, as well as summary commands like `git shortlog -s` and `git shortlog -sn`, and various GUIs for Git.

I've also added -f to the sort command as it appeared to (mostly) be sorted case-insensitively already. Without this option, running the script resulted in all lowercase names being moved to the end of the list (tried both macOS/BSD's default sort, and the one from gnu-coreutils). I'm guessing the previous run was done on a machine with a different implementation or override present that uses some kind of hybrid by default.