### PR TITLE
Support `import.meta` in scripts (via `allowImportExportEverywhere`)

### DIFF
--- a/acorn/README.md
+++ b/acorn/README.md
@@ -90,8 +90,10 @@ required):
 
 - **allowImportExportEverywhere**: By default, `import` and `export`
   declarations can only appear at a program's top level. Setting this
-  option to `true` allows them anywhere where a statement is allowed.
-  
+  option to `true` allows them anywhere where a statement is allowed,
+  and also allows `import.meta` expressions to appear in scripts
+  (when `sourceType` is not `"module"`).
+
 - **allowAwaitOutsideFunction**: By default, `await` expressions can
   only appear inside `async` functions. Setting this option to
   `true` allows to have top-level `await` expressions. They are

--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -513,7 +513,7 @@ pp.parseImportMeta = function(node) {
     this.raiseRecoverable(node.property.start, "The only valid meta property for import is 'import.meta'")
   if (containsEsc)
     this.raiseRecoverable(node.start, "'import.meta' must not contain escaped characters")
-  if (this.options.sourceType !== "module")
+  if (this.options.sourceType !== "module" && !this.options.allowImportExportEverywhere)
     this.raiseRecoverable(node.start, "Cannot use 'import.meta' outside a module")
 
   return this.finishNode(node, "MetaProperty")

--- a/acorn/src/options.js
+++ b/acorn/src/options.js
@@ -33,7 +33,8 @@ export const defaultOptions = {
   // error.
   allowReturnOutsideFunction: false,
   // When enabled, import/export statements are not constrained to
-  // appearing at the top of the program.
+  // appearing at the top of the program, and an import.meta expression
+  // in a script isn't considered an error.
   allowImportExportEverywhere: false,
   // When enabled, await identifiers are allowed to appear at the top-level scope,
   // but they are still not allowed in non-async functions.

--- a/test/tests-import-meta.js
+++ b/test/tests-import-meta.js
@@ -41,6 +41,41 @@ test(
 );
 
 test(
+  "import.meta",
+  {
+    "type": "Program",
+    "start": 0,
+    "end": 11,
+    "body": [
+      {
+        "type": "ExpressionStatement",
+        "start": 0,
+        "end": 11,
+        "expression": {
+          "type": "MetaProperty",
+          "start": 0,
+          "end": 11,
+          "meta": {
+            "type": "Identifier",
+            "start": 0,
+            "end": 6,
+            "name": "import"
+          },
+          "property": {
+            "type": "Identifier",
+            "start": 7,
+            "end": 11,
+            "name": "meta"
+          }
+        }
+      }
+    ],
+    "sourceType": "script"
+  },
+  { ecmaVersion: 11, sourceType: "script", allowImportExportEverywhere: true }
+);
+
+test(
   "import.meta.url",
   {
     "type": "Program",


### PR DESCRIPTION
Previously the acorn parser would always throw an error when it hits
an `import.meta` expression while parsing a script, while it would
happily parse `import` and `export` (and in particular dynamic
`import()`) outside of modules as long as `allowImportExportEverywhere`
was set to `true`. This changes the behavior to also allow `import.meta`
in scripts as long as `allowImportExportEverywhere` is `true`.

The motivation here is for the Chromium DevTools pretty print feature,
where we use the acorn parser, and where we don't necessarily know for
sure whether the user is trying to pretty print a module or a script,
and for the purpose of pretty printing that doesn't really matter anyways.

Issue: https://crbug.com/1185578