### PR TITLE
Don't generate sourcemaps

### DIFF
--- a/acorn-loose/rollup.config.js
+++ b/acorn-loose/rollup.config.js
@@ -7,14 +7,12 @@ export default {
       file: "acorn-loose/dist/acorn-loose.js",
       format: "umd",
       name: "acorn.loose",
-      sourcemap: true,
       external: ["acorn"],
       globals: {acorn: "acorn"}
     },
     {
       file: "acorn-loose/dist/acorn-loose.mjs",
       format: "es",
-      sourcemap: true,
       external: ["acorn"],
       globals: {acorn: "acorn"}
     }

--- a/acorn-walk/rollup.config.js
+++ b/acorn-walk/rollup.config.js
@@ -6,13 +6,11 @@ export default {
     {
       file: "acorn-walk/dist/walk.js",
       format: "umd",
-      name: "acorn.walk",
-      sourcemap: true
+      name: "acorn.walk"
     },
     {
       file: "acorn-walk/dist/walk.mjs",
-      format: "es",
-      sourcemap: true
+      format: "es"
     }
   ],
   plugins: [

--- a/acorn/rollup.config.js
+++ b/acorn/rollup.config.js
@@ -6,13 +6,11 @@ export default {
     {
       file: "acorn/dist/acorn.js",
       format: "umd",
-      name: "acorn",
-      sourcemap: true
+      name: "acorn"
     },
     {
       file: "acorn/dist/acorn.mjs",
-      format: "es",
-      sourcemap: true
+      format: "es"
     }
   ],
   plugins: [


### PR DESCRIPTION
Based on the discussion in https://github.com/eslint/eslint/issues/14098 I took a look at all the files in eslint's dependencies and I noticed that the **SourceMaps in acorn make up ~46% of its package size**. While only a very small part of the total, they are the two largest single files in all of eslint.

There's obviously a trade off between a smaller package and the potential better debugging enabled by SourceMaps. Since Node.js doesn't load SourceMaps [by default](https://nodejs.org/dist/latest-v12.x/docs/api/cli.html#cli_enable_source_maps) nor does Webpack without a [plugin](https://webpack.js.org/loaders/source-map-loader/), I think they're of very limited value. The only exception would be someone loading the UMD directly in a browser - I'm not certain how common this is for acorn.

I think it's worth considering to no longer generate & ship these files to reduce the package size by ~46%.