### PR TITLE
Make await x ** y fail to parse

### DIFF
--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -3526,4 +3526,16 @@ testFail("abc: async function a() {}", "Unexpected token (1:5)", {ecmaVersion: 8
 
 testFail("(async() => { await 4 ** 2 })()", "Unexpected token (1:22)", {ecmaVersion: 8})
 
+test("(async() => { await (4 ** 2) })()", {}, {ecmaVersion: 8})
+
+testFail("async() => (await 1 ** 3)", "Unexpected token (1:20)", {ecmaVersion: 8})
+
+test("async() => (await (1 ** 3))", {}, {ecmaVersion: 8})
+
+testFail("async() => await 5 ** 6", "Unexpected token (1:19)", {ecmaVersion: 8})
+
+test("async() => await (5 ** 6)", {}, {ecmaVersion: 8})
+
+testFail("async() => await (5) ** 6", "Unexpected token (1:21)", {ecmaVersion: 8})
+
 testFail("4 + async() => 2", "Unexpected token (1:12)", {ecmaVersion: 8, loose: false})

--- a/test/tests-es7.js
+++ b/test/tests-es7.js
@@ -228,6 +228,8 @@ testFail("~3 ** 2;", "Unexpected token (1:3)", { ecmaVersion: 7 });
 testFail("!1 ** 2;", "Unexpected token (1:3)", { ecmaVersion: 7 });
 testFail("-2** 2;", "Unexpected token (1:2)", { ecmaVersion: 7 });
 testFail("+2** 2;", "Unexpected token (1:2)", { ecmaVersion: 7 });
+testFail("-(i--) ** 2", "Unexpected token (1:7)", {ecmaVersion: 7});
+testFail("+(i--) ** 2", "Unexpected token (1:7)", {ecmaVersion: 7});
 
 // make sure base operand check doesn't affect other operators
 test("-a * 5", {


### PR DESCRIPTION
Implement grammar restrictions to prevent ambiguity as per spec.  Test cases that fail with the old version and succeed with the new version are introduced.

Fixes:  https://github.com/acornjs/acorn/issues/1028

The [previous attempt](https://github.com/acornjs/acorn/commit/848d14e20653a211b06c8e167810bd4fae2173cf) at fixing this did not cover all cases.