### PR TITLE
Implement ES2022 RegExp Match Indices

### DIFF
--- a/acorn/src/regexp.js
+++ b/acorn/src/regexp.js
@@ -8,7 +8,7 @@ const pp = Parser.prototype
 export class RegExpValidationState {
   constructor(parser) {
     this.parser = parser
-    this.validFlags = `gim${parser.options.ecmaVersion >= 6 ? "uy" : ""}${parser.options.ecmaVersion >= 9 ? "s" : ""}`
+    this.validFlags = `gim${parser.options.ecmaVersion >= 6 ? "uy" : ""}${parser.options.ecmaVersion >= 9 ? "s" : ""}${parser.options.ecmaVersion >= 13 ? "d" : ""}`
     this.unicodeProperties = UNICODE_PROPERTY_VALUES[parser.options.ecmaVersion >= 12 ? 12 : parser.options.ecmaVersion]
     this.source = ""
     this.flags = ""

--- a/test/run.js
+++ b/test/run.js
@@ -13,6 +13,7 @@
   require("./tests-regexp.js");
   require("./tests-regexp-2018.js");
   require("./tests-regexp-2020.js");
+  require("./tests-regexp-2022.js");
   require("./tests-json-superset.js");
   require("./tests-optional-catch-binding.js");
   require("./tests-bigint.js");

--- a/test/tests-regexp-2022.js
+++ b/test/tests-regexp-2022.js
@@ -1,0 +1,8 @@
+if (typeof exports != "undefined") {
+  var test = require("./driver.js").test
+  var testFail = require("./driver.js").testFail
+}
+
+// https://github.com/tc39/ecma262/pull/1713
+testFail("/a+(?<Z>z)?/d", "Invalid regular expression flag (1:1)", { ecmaVersion: 2021 })
+test("/a+(?<Z>z)?/d", {}, { ecmaVersion: 2022 })


### PR DESCRIPTION
ES2022 RegExp Match Indices have arrived at Stage 4. This PR implements it.
This PR modifies the parser to accept the d flag of regex literals.

**References**

Proposal: https://github.com/tc39/proposal-regexp-match-indices
Stage update: https://github.com/tc39/proposals/commit/f0adbe134df9bb73d002af4d23ebc710d0d56972
Ecma262 update: tc39/ecma262#1713