### PR TITLE
Change `allowAwaitOutsideFunction` to be enabled by default when `ecmaVersion` >= 2022

### DIFF
--- a/acorn/README.md
+++ b/acorn/README.md
@@ -94,8 +94,9 @@ required):
   and also allows `import.meta` expressions to appear in scripts
   (when `sourceType` is not `"module"`).
 
-- **allowAwaitOutsideFunction**: By default, `await` expressions can
-  only appear inside `async` functions. Setting this option to
+- **allowAwaitOutsideFunction**: If `false`, `await` expressions can
+  only appear inside `async` functions. Defaults to `true` for
+  `ecmaVersion` 2022 and later, `false` for lower versions. Setting this option to
   `true` allows to have top-level `await` expressions. They are
   still not allowed in non-`async` functions, though.
 

--- a/acorn/src/options.js
+++ b/acorn/src/options.js
@@ -36,9 +36,10 @@ export const defaultOptions = {
   // appearing at the top of the program, and an import.meta expression
   // in a script isn't considered an error.
   allowImportExportEverywhere: false,
+  // By default, await identifiers are allowed to appear at the top-level scope only if ecmaVersion >= 2022.
   // When enabled, await identifiers are allowed to appear at the top-level scope,
   // but they are still not allowed in non-async functions.
-  allowAwaitOutsideFunction: false,
+  allowAwaitOutsideFunction: null,
   // When enabled, hashbang directive in the beginning of file
   // is allowed and treated as a line comment.
   allowHashBang: false,
@@ -114,6 +115,8 @@ export function getOptions(opts) {
 
   if (options.allowReserved == null)
     options.allowReserved = options.ecmaVersion < 5
+  if (options.allowAwaitOutsideFunction == null)
+    options.allowAwaitOutsideFunction = options.ecmaVersion >= 13
 
   if (isArray(options.onToken)) {
     let tokens = options.onToken

--- a/test/tests-await-top-level.js
+++ b/test/tests-await-top-level.js
@@ -36,3 +36,33 @@ testFail("function foo() {return await 1}", "Unexpected token (1:29)", {
   allowAwaitOutsideFunction: true,
   ecmaVersion: 8
 })
+// ES2022
+test("await 1", {
+  "type": "Program",
+  "start": 0,
+  "end": 7,
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "start": 0,
+      "end": 7,
+      "expression": {
+        "type": "AwaitExpression",
+        "start": 0,
+        "end": 7,
+        "argument": {
+          "type": "Literal",
+          "start": 6,
+          "end": 7,
+          "value": 1
+        }
+      }
+    }
+  ]
+}, {ecmaVersion: 13})
+testFail("function foo() {return await 1}", "Unexpected token (1:29)", {ecmaVersion: 13})
+testFail("await 1", "Unexpected token (1:6)", {
+  allowAwaitOutsideFunction: false,
+  ecmaVersion: 13
+})
+testFail("await 1", "Unexpected token (1:6)", {ecmaVersion: 12})


### PR DESCRIPTION
ES2022 Top-level `await` have arrived at Stage 4.
This PR changes to enable `allowAwaitOutsideFunction` by default when ecmaVersion >= 2022.

**References**

Proposal: https://github.com/tc39/proposal-top-level-await
Stage update: tc39/proposals@99fa42a
Ecma262 update: tc39/ecma262#2408

