### PR TITLE
Add 2022 (and 13) as allowed ecmaVersion

### DIFF
--- a/acorn/README.md
+++ b/acorn/README.md
@@ -54,9 +54,10 @@ required):
 
 - **ecmaVersion**: Indicates the ECMAScript version to parse. Must be
   either 3, 5, 6 (or 2015), 7 (2016), 8 (2017), 9 (2018), 10 (2019),
-  11 (2020), or 12 (2021, partial support), or `"latest"` (the latest
-  the library supports). This influences support for strict mode, the
-  set of reserved words, and support for new syntax features.
+  11 (2020), 12 (2021, partial support), 13 (2022, partial support)
+  or `"latest"` (the latest the library supports). This influences
+  support for strict mode, the set of reserved words, and support
+  for new syntax features.
 
   **NOTE**: Only 'stage 4' (finalized) ECMAScript features are being
   implemented by Acorn. Other proposed new features must be

--- a/acorn/dist/acorn.d.ts
+++ b/acorn/dist/acorn.d.ts
@@ -12,7 +12,7 @@ declare namespace acorn {
   }
 
   interface Options {
-    ecmaVersion: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | 2021 | 'latest'
+    ecmaVersion: 3 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12 | 13 | 2015 | 2016 | 2017 | 2018 | 2019 | 2020 | 2021 | 2022 | 'latest'
     sourceType?: 'script' | 'module'
     onInsertedSemicolon?: (lastTokEnd: number, lastTokEndLoc?: Position) => void
     onTrailingComma?: (lastTokEnd: number, lastTokEndLoc?: Position) => void

--- a/acorn/src/options.js
+++ b/acorn/src/options.js
@@ -7,9 +7,10 @@ import {SourceLocation} from "./locutil.js"
 export const defaultOptions = {
   // `ecmaVersion` indicates the ECMAScript version to parse. Must be
   // either 3, 5, 6 (or 2015), 7 (2016), 8 (2017), 9 (2018), 10
-  // (2019), 11 (2020), 12 (2021), or `"latest"` (the latest version
-  // the library supports). This influences support for strict mode,
-  // the set of reserved words, and support for new syntax features.
+  // (2019), 11 (2020), 12 (2021), 13 (2022), or `"latest"` (the
+  // latest version the library supports). This influences support
+  // for strict mode, the set of reserved words, and support for
+  // new syntax features.
   ecmaVersion: null,
   // `sourceType` indicates the mode the code should be parsed in.
   // Can be either `"script"` or `"module"`. This influences global


### PR DESCRIPTION
Some features are only supported in 2022 and above. While some
of the existing tests already specify 2022 as ecmaVersion (or
the equivalent 13 level), it wasn't explicitly listed as allowed
option in the documentation or types.

Therefore, add the supported ecmaVersion to the list and types.
Downstream, we are using acorn and want to specify ecmaVersion
2022 for class field support, but TypeScript prohibits us from
doing that at the moment.