### PR TITLE
Bump actions/checkout to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and test
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - uses: bahmutov/npm-install@v1
         with:
           useLockFile: false


### PR DESCRIPTION
## Changes:

- Use the latest stable version of `actions/checkout`

## Context:

See the changelog for the first v2 release here: https://github.com/actions/checkout/releases/tag/v2.0.0
You should also check the changelogs for the newer releases (current latest release is `2.3.4`).