### PR TITLE
add missing "export const base" in walk.d.ts

### DIFF
--- a/acorn-walk/dist/walk.d.ts
+++ b/acorn-walk/dist/walk.d.ts
@@ -109,4 +109,6 @@ declare module "acorn-walk" {
   ): Found<TState> | undefined;
 
   export const findNodeAfter: typeof findNodeAround;
+
+  export const base: object;
 }

--- a/acorn-walk/dist/walk.d.ts
+++ b/acorn-walk/dist/walk.d.ts
@@ -110,5 +110,5 @@ declare module "acorn-walk" {
 
   export const findNodeAfter: typeof findNodeAround;
 
-  export const base: object;
+  export const base: RecursiveVisitors<any>;
 }


### PR DESCRIPTION
Just added at the end:

```diff
   export const findNodeAfter: typeof findNodeAround;
+  export const base: object;
}
```

fix [1043](https://github.com/acornjs/acorn/issues/1043)