### PR TITLE
test: allow test262 for regexp-match-indices

### DIFF
--- a/bin/run_test262.js
+++ b/bin/run_test262.js
@@ -4,7 +4,6 @@ const run = require("test262-parser-runner")
 const parse = require("../acorn").parse
 
 const unsupportedFeatures = [
-  "regexp-match-indices",
   "arbitrary-module-namespace-names",
   "import-assertions"
 ];


### PR DESCRIPTION
support added with: https://github.com/acornjs/acorn/blob/master/acorn/CHANGELOG.md#830-2021-05-31