### PR TITLE
ci: use official actions/setup-node@v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,7 @@ jobs:
     name: Build and test
     steps:
       - uses: actions/checkout@v2
-      - uses: bahmutov/npm-install@v1
-        with:
-          useLockFile: false
+      - uses: actions/setup-node@v2
+      - run: npm install
       - run: npm test
       - run: npm run test:test262


### PR DESCRIPTION
https://github.com/actions/setup-node

the `ci runtime` is the same as the other 3rd party action, which uses this official one under the hood: https://github.com/acornjs/acorn/runs/3872638742?check_suite_focus=true