### PR TITLE
Fix of Fix: Propagation of forInit down to arrow functions

### DIFF
--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -638,7 +638,7 @@ pp.parseParenItem = function(item) {
 }
 
 pp.parseParenArrowList = function(startPos, startLoc, exprList, forInit) {
-  return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, forInit)
+  return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, false, forInit)
 }
 
 // New's precedence is slightly tricky. It must allow its argument to


### PR DESCRIPTION
Commit f6f42506754 added the forInit argument in a call to
parseArrowExpression() but forgot to also add isAsync, which was
previously ommitted at that call site.