### PR TITLE
Use file for test262 unsupported features

### DIFF
--- a/bin/run_test262.js
+++ b/bin/run_test262.js
@@ -3,19 +3,21 @@ const path = require("path")
 const run = require("test262-parser-runner")
 const parse = require("../acorn").parse
 
-const unsupportedFeatures = [
-  "arbitrary-module-namespace-names",
-  "import-assertions"
-];
+function loadList(filename) {
+  return fs.readFileSync(filename, "utf8")
+      .split("\n")
+      .filter(Boolean)
+}
 
 run(
   (content, {sourceType}) => parse(content, {sourceType, ecmaVersion: 13, allowHashBang: true, allowAwaitOutsideFunction: sourceType === "module"}),
   {
     testsDirectory: path.dirname(require.resolve("test262/package.json")),
-    skip: test => (test.attrs.features && unsupportedFeatures.some(f => test.attrs.features.includes(f))),
-    whitelist: fs.readFileSync("./bin/test262.whitelist", "utf8")
-      .split("\n")
-      .filter(Boolean)
-      .map(filename => path.sep !== "/" ? filename.split("/").join(path.sep) : filename)
+    skip: test => test.attrs.features &&
+      loadList("./bin/test262.unsupported-features").some(f => test.attrs.features.includes(f)
+    ),
+    whitelist: loadList("./bin/test262.whitelist")
+      .map(filename => path.sep === "/" ? filename : filename.split("/").join(path.sep)
+    )
   }
 )

--- a/bin/test262.unsupported-features
+++ b/bin/test262.unsupported-features
@@ -1,0 +1,2 @@
+arbitrary-module-namespace-names
+import-assertions


### PR DESCRIPTION
uses a text file for `test262 unsupported features`, same as `test262.whitelist`.