### PR TITLE
Support ES2022 module string names syntax

### DIFF
--- a/acorn-loose/src/statement.js
+++ b/acorn-loose/src/statement.js
@@ -530,13 +530,13 @@ lp.parseImportSpecifiers = function() {
     while (!this.closes(tt.braceR, indent + (this.curLineStart <= continuedLine ? 1 : 0), line)) {
       let elt = this.startNode()
       if (this.eat(tt.star)) {
-        elt.local = this.eatContextual("as") ? this.parseIdent() : this.dummyIdent()
+        elt.local = this.eatContextual("as") ? this.parseModuleExportName() : this.dummyIdent()
         this.finishNode(elt, "ImportNamespaceSpecifier")
       } else {
         if (this.isContextual("from")) break
-        elt.imported = this.parseIdent()
+        elt.imported = this.parseModuleExportName()
         if (isDummy(elt.imported)) break
-        elt.local = this.eatContextual("as") ? this.parseIdent() : elt.imported
+        elt.local = this.eatContextual("as") ? this.parseModuleExportName() : elt.imported
         this.finishNode(elt, "ImportSpecifier")
       }
       elts.push(elt)
@@ -557,9 +557,9 @@ lp.parseExportSpecifierList = function() {
   while (!this.closes(tt.braceR, indent + (this.curLineStart <= continuedLine ? 1 : 0), line)) {
     if (this.isContextual("from")) break
     let elt = this.startNode()
-    elt.local = this.parseIdent()
+    elt.local = this.parseModuleExportName()
     if (isDummy(elt.local)) break
-    elt.exported = this.eatContextual("as") ? this.parseIdent() : elt.local
+    elt.exported = this.eatContextual("as") ? this.parseModuleExportName() : elt.local
     this.finishNode(elt, "ExportSpecifier")
     elts.push(elt)
     this.eat(tt.comma)
@@ -567,4 +567,10 @@ lp.parseExportSpecifierList = function() {
   this.eat(tt.braceR)
   this.popCx()
   return elts
+}
+
+lp.parseModuleExportName = function() {
+  return this.options.ecmaVersion >= 13 && this.tok.type === tt.string
+    ? this.parseExprAtom()
+    : this.parseIdent()
 }

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -890,6 +890,10 @@ pp.parseExport = function(node, exports) {
         this.checkUnreserved(spec.local)
         // check if export is defined
         this.checkLocalExport(spec.local)
+
+        if (spec.local.type === "Literal") {
+          this.raise(spec.local.start, "A string literal cannot be used as an exported binding without `from`.")
+        }
       }
 
       node.source = null

--- a/acorn/src/util.js
+++ b/acorn/src/util.js
@@ -11,3 +11,5 @@ export const isArray = Array.isArray || ((obj) => (
 export function wordsRegexp(words) {
   return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$")
 }
+
+export const loneSurrogate = /[\uD800-\uDFFF]/u

--- a/test/run.js
+++ b/test/run.js
@@ -25,6 +25,7 @@
   require("./tests-logical-assignment-operators.js");
   require("./tests-numeric-separators.js");
   require("./tests-class-features-2022.js");
+  require("./tests-module-string-names.js");
   var acorn = require("../acorn")
   var acorn_loose = require("../acorn-loose")
 

--- a/test/tests-module-string-names.js
+++ b/test/tests-module-string-names.js
@@ -319,3 +319,9 @@ test(
   },
   { sourceType: "module", ecmaVersion: 13 }
 );
+
+testFail(
+  'export { "學而時習之，不亦說乎？", "吾道一以貫之。" as "忠恕。" };',
+  "A string literal cannot be used as an exported binding without `from`. (1:9)",
+  { sourceType: "module", ecmaVersion: 13 }
+);

--- a/test/tests-module-string-names.js
+++ b/test/tests-module-string-names.js
@@ -325,3 +325,9 @@ testFail(
   "A string literal cannot be used as an exported binding without `from`. (1:9)",
   { sourceType: "module", ecmaVersion: 13 }
 );
+
+testFail(
+  'const foo = 42; export { foo as "\ud800\udbff" }',
+  "An export name cannot include a lone surrogate. (1:32)",
+  { sourceType: "module", ecmaVersion: 13 }
+);

--- a/test/tests-module-string-names.js
+++ b/test/tests-module-string-names.js
@@ -331,3 +331,9 @@ testFail(
   "An export name cannot include a lone surrogate. (1:32)",
   { sourceType: "module", ecmaVersion: 13 }
 );
+
+testFail(
+  'const foo = 43, bar = 32; export { foo, bar as "foo" };',
+  "Duplicate export 'foo' (1:47)",
+  { sourceType: "module", ecmaVersion: 13 }
+);

--- a/test/tests-module-string-names.js
+++ b/test/tests-module-string-names.js
@@ -211,3 +211,111 @@ test(
   },
   { sourceType: "module", ecmaVersion: 13 }
 );
+
+test(
+  'import { "foo" as bar, "default" as qux } from "module-a";',
+  {
+    type: "Program",
+    start: 0,
+    end: 58,
+    body: [
+      {
+        type: "ImportDeclaration",
+        start: 0,
+        end: 58,
+        specifiers: [
+          {
+            type: "ImportSpecifier",
+            start: 9,
+            end: 21,
+            imported: {
+              type: "Literal",
+              start: 9,
+              end: 14,
+              value: "foo",
+              raw: '"foo"',
+            },
+            local: {
+              type: "Identifier",
+              start: 18,
+              end: 21,
+              name: "bar",
+            },
+          },
+          {
+            type: "ImportSpecifier",
+            start: 23,
+            end: 39,
+            imported: {
+              type: "Literal",
+              start: 23,
+              end: 32,
+              value: "default",
+              raw: '"default"',
+            },
+            local: {
+              type: "Identifier",
+              start: 36,
+              end: 39,
+              name: "qux",
+            },
+          },
+        ],
+        source: {
+          type: "Literal",
+          start: 47,
+          end: 57,
+          value: "module-a",
+          raw: '"module-a"',
+        },
+      },
+    ],
+    sourceType: "module",
+  },
+  { sourceType: "module", ecmaVersion: 13 }
+);
+
+test(
+  'import { "default" as quotation } from "Confucius";',
+  {
+    type: "Program",
+    start: 0,
+    end: 51,
+    body: [
+      {
+        type: "ImportDeclaration",
+        start: 0,
+        end: 51,
+        specifiers: [
+          {
+            type: "ImportSpecifier",
+            start: 9,
+            end: 31,
+            imported: {
+              type: "Literal",
+              start: 9,
+              end: 18,
+              value: "default",
+              raw: '"default"',
+            },
+            local: {
+              type: "Identifier",
+              start: 22,
+              end: 31,
+              name: "quotation",
+            },
+          },
+        ],
+        source: {
+          type: "Literal",
+          start: 39,
+          end: 50,
+          value: "Confucius",
+          raw: '"Confucius"',
+        },
+      },
+    ],
+    sourceType: "module",
+  },
+  { sourceType: "module", ecmaVersion: 13 }
+);

--- a/test/tests-module-string-names.js
+++ b/test/tests-module-string-names.js
@@ -1,0 +1,213 @@
+if (typeof exports != "undefined") {
+  var test = require("./driver.js").test;
+  var testFail = require("./driver.js").testFail;
+}
+
+test(
+  'import {"學而時習之，不亦說乎？" as quotation} from "Confucius";',
+  {
+    type: "Program",
+    start: 0,
+    end: 53,
+    body: [
+      {
+        type: "ImportDeclaration",
+        start: 0,
+        end: 53,
+        specifiers: [
+          {
+            type: "ImportSpecifier",
+            start: 8,
+            end: 34,
+            imported: {
+              type: "Literal",
+              start: 8,
+              end: 21,
+              value: "學而時習之，不亦說乎？",
+              raw: '"學而時習之，不亦說乎？"',
+            },
+            local: {
+              type: "Identifier",
+              start: 25,
+              end: 34,
+              name: "quotation",
+            },
+          },
+        ],
+        source: {
+          type: "Literal",
+          start: 41,
+          end: 52,
+          value: "Confucius",
+          raw: '"Confucius"',
+        },
+      },
+    ],
+    sourceType: "module",
+  },
+  { sourceType: "module", ecmaVersion: 13 }
+);
+
+test(
+  'const quotation = ""; export { quotation as "學而時習之，不亦說乎？" };',
+  {
+    type: "Program",
+    start: 0,
+    end: 60,
+    body: [
+      {
+        type: "VariableDeclaration",
+        start: 0,
+        end: 21,
+        declarations: [
+          {
+            type: "VariableDeclarator",
+            start: 6,
+            end: 20,
+            id: {
+              type: "Identifier",
+              start: 6,
+              end: 15,
+              name: "quotation",
+            },
+            init: {
+              type: "Literal",
+              start: 18,
+              end: 20,
+              value: "",
+              raw: '""',
+            },
+          },
+        ],
+        kind: "const",
+      },
+      {
+        type: "ExportNamedDeclaration",
+        start: 22,
+        end: 60,
+        declaration: null,
+        specifiers: [
+          {
+            type: "ExportSpecifier",
+            start: 31,
+            end: 57,
+            local: {
+              type: "Identifier",
+              start: 31,
+              end: 40,
+              name: "quotation",
+            },
+            exported: {
+              type: "Literal",
+              start: 44,
+              end: 57,
+              value: "學而時習之，不亦說乎？",
+              raw: '"學而時習之，不亦說乎？"',
+            },
+          },
+        ],
+        source: null,
+      },
+    ],
+    sourceType: "module",
+  },
+  { sourceType: "module", ecmaVersion: 13 }
+);
+
+test(
+  'export * as "忠恕。" from "Confucius";',
+  {
+    type: "Program",
+    start: 0,
+    end: 35,
+    body: [
+      {
+        type: "ExportAllDeclaration",
+        start: 0,
+        end: 35,
+        exported: {
+          type: "Literal",
+          start: 12,
+          end: 17,
+          value: "忠恕。",
+          raw: '"忠恕。"',
+        },
+        source: {
+          type: "Literal",
+          start: 23,
+          end: 34,
+          value: "Confucius",
+          raw: '"Confucius"',
+        },
+      },
+    ],
+    sourceType: "module",
+  },
+  { sourceType: "module", ecmaVersion: 13 }
+);
+
+test(
+  'export { "學而時習之，不亦說乎？", "吾道一以貫之。" as "忠恕。" } from "Confucius";',
+  {
+    type: "Program",
+    start: 0,
+    end: 62,
+    body: [
+      {
+        type: "ExportNamedDeclaration",
+        start: 0,
+        end: 62,
+        declaration: null,
+        specifiers: [
+          {
+            type: "ExportSpecifier",
+            start: 9,
+            end: 22,
+            local: {
+              type: "Literal",
+              start: 9,
+              end: 22,
+              value: "學而時習之，不亦說乎？",
+              raw: '"學而時習之，不亦說乎？"',
+            },
+            exported: {
+              type: "Literal",
+              start: 9,
+              end: 22,
+              value: "學而時習之，不亦說乎？",
+              raw: '"學而時習之，不亦說乎？"',
+            },
+          },
+          {
+            type: "ExportSpecifier",
+            start: 24,
+            end: 42,
+            local: {
+              type: "Literal",
+              start: 24,
+              end: 33,
+              value: "吾道一以貫之。",
+              raw: '"吾道一以貫之。"',
+            },
+            exported: {
+              type: "Literal",
+              start: 37,
+              end: 42,
+              value: "忠恕。",
+              raw: '"忠恕。"',
+            },
+          },
+        ],
+        source: {
+          type: "Literal",
+          start: 50,
+          end: 61,
+          value: "Confucius",
+          raw: '"Confucius"',
+        },
+      },
+    ],
+    sourceType: "module",
+  },
+  { sourceType: "module", ecmaVersion: 13 }
+);


### PR DESCRIPTION
ES2022 allows export string names like below:

```js
const foo = 42;
export { foo as " 😆 " }
```

```js
import { " 😆 " as foo } from "mod";
```

- https://github.com/estree/estree/pull/269
- https://github.com/tc39/ecma262/pull/2154