### PR TITLE
Convert constructor function to class

### DIFF
--- a/acorn/src/parseutil.js
+++ b/acorn/src/parseutil.js
@@ -111,13 +111,15 @@ pp.unexpected = function(pos) {
   this.raise(pos != null ? pos : this.start, "Unexpected token")
 }
 
-export function DestructuringErrors() {
-  this.shorthandAssign =
-  this.trailingComma =
-  this.parenthesizedAssign =
-  this.parenthesizedBind =
-  this.doubleProto =
-    -1
+export class DestructuringErrors {
+  constructor() {
+    this.shorthandAssign =
+    this.trailingComma =
+    this.parenthesizedAssign =
+    this.parenthesizedBind =
+    this.doubleProto =
+      -1
+  }
 }
 
 pp.checkPatternErrors = function(refDestructuringErrors, isAssign) {


### PR DESCRIPTION
just for consistency: aligns with all other constructor functions being a class.