### PR TITLE
License updated for new year

### DIFF
--- a/acorn/LICENSE
+++ b/acorn/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (C) 2012-2020 by various contributors (see AUTHORS)
+Copyright (C) 2012-2022 by various contributors (see AUTHORS)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Just happened to notice that the copyright year needed to be updated when I was taking a look at the license.