### PR TITLE
remove redundant `codePointToString`

### DIFF
--- a/acorn/src/regexp.js
+++ b/acorn/src/regexp.js
@@ -1,7 +1,7 @@
 import {isIdentifierStart, isIdentifierChar} from "./identifier.js"
 import {Parser} from "./state.js"
 import UNICODE_PROPERTY_VALUES from "./unicode-property-data.js"
-import {hasOwn} from "./util.js"
+import {hasOwn, codePointToString} from "./util.js"
 
 const pp = Parser.prototype
 
@@ -87,12 +87,6 @@ export class RegExpValidationState {
     }
     return false
   }
-}
-
-function codePointToString(ch) {
-  if (ch <= 0xFFFF) return String.fromCharCode(ch)
-  ch -= 0x10000
-  return String.fromCharCode((ch >> 10) + 0xD800, (ch & 0x03FF) + 0xDC00)
 }
 
 /**

--- a/acorn/src/tokenize.js
+++ b/acorn/src/tokenize.js
@@ -4,6 +4,7 @@ import {Parser} from "./state.js"
 import {SourceLocation} from "./locutil.js"
 import {RegExpValidationState} from "./regexp.js"
 import {lineBreak, nextLineBreak, isNewLine, nonASCIIwhitespace} from "./whitespace.js"
+import {codePointToString} from "./util"
 
 // Object type used to represent tokens. Note that normally, tokens
 // simply exist as properties on the parser object. This is only
@@ -560,13 +561,6 @@ pp.readCodePoint = function() {
     code = this.readHexChar(4)
   }
   return code
-}
-
-function codePointToString(code) {
-  // UTF-16 Decoding
-  if (code <= 0xFFFF) return String.fromCharCode(code)
-  code -= 0x10000
-  return String.fromCharCode((code >> 10) + 0xD800, (code & 1023) + 0xDC00)
 }
 
 pp.readString = function(quote) {

--- a/acorn/src/util.js
+++ b/acorn/src/util.js
@@ -12,4 +12,11 @@ export function wordsRegexp(words) {
   return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$")
 }
 
+export function codePointToString(code) {
+  // UTF-16 Decoding
+  if (code <= 0xFFFF) return String.fromCharCode(code)
+  code -= 0x10000
+  return String.fromCharCode((code >> 10) + 0xD800, (code & 1023) + 0xDC00)
+}
+
 export const loneSurrogate = /[\uD800-\uDFFF]/u


### PR DESCRIPTION
Remove redundant function:

The following two images show the impact of redundant code on the dist file:

![origin_img_v2_7f4f3857-a8b7-48d0-ae5d-e98d89b6e58g](https://user-images.githubusercontent.com/30187863/160237654-20b6a1d2-7c56-4932-844a-273e2c985ea8.jpg)

![origin_img_v2_47705f44-db3d-45ce-9e20-28439747bc2g](https://user-images.githubusercontent.com/30187863/160237659-6be2cf23-ecc5-4527-a270-99ad0a386c5a.jpg)
