### PR TITLE
Bump test262 to latest commit

### DIFF
--- a/bin/test262.unsupported-features
+++ b/bin/test262.unsupported-features
@@ -1,1 +1,2 @@
 import-assertions
+regexp-v-flag

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^5.2.0",
     "rollup": "^2.60.2",
-    "test262": "git+https://github.com/tc39/test262.git#08a9fc2b974f83a9835174cede20a7935f126015",
+    "test262": "git+https://github.com/tc39/test262.git#f0bf5dfcea7bce15eb4f7e0b0e97b2a5f3e830c5",
     "test262-parser-runner": "^0.5.0"
   }
 }


### PR DESCRIPTION
exclude currently failing tests for stage 3 `RegExp v flag with set notation + properties of strings` https://github.com/tc39/proposal-regexp-set-notation

before:
```
Summary:
 ✔ 79109 valid programs parsed without error
 ✔ 7893 invalid programs produced a parsing error
 ✔ 0 invalid programs did not produce a parsing error (and allowed by the whitelist file)
 ✔ 0 valid programs produced a parsing error (and allowed by the whitelist file)
 ✔ 169 programs were skipped
```

after:
```
Summary:
 ✔ 80859 valid programs parsed without error
 ✔ 7893 invalid programs produced a parsing error
 ✔ 0 invalid programs did not produce a parsing error (and allowed by the whitelist file)
 ✔ 0 valid programs produced a parsing error (and allowed by the whitelist file)
 ✔ 233 programs were skipped
```