### PR TITLE
Adding a missing .js extension

### DIFF
--- a/acorn/src/tokenize.js
+++ b/acorn/src/tokenize.js
@@ -4,7 +4,7 @@ import {Parser} from "./state.js"
 import {SourceLocation} from "./locutil.js"
 import {RegExpValidationState} from "./regexp.js"
 import {lineBreak, nextLineBreak, isNewLine, nonASCIIwhitespace} from "./whitespace.js"
-import {codePointToString} from "./util"
+import {codePointToString} from "./util.js"
 
 // Object type used to represent tokens. Note that normally, tokens
 // simply exist as properties on the parser object. This is only


### PR DESCRIPTION
Some module loaders (like the default module loader in GraalVM) is not able to resolve this import otherwise.