### PR TITLE
Make Comment type compatible with estree's Comment

### DIFF
--- a/acorn/dist/acorn.d.ts
+++ b/acorn/dist/acorn.d.ts
@@ -224,7 +224,7 @@ declare namespace acorn {
   }
 
   interface Comment extends AbstractToken {
-    type: string
+    type: 'Line' | 'Block'
     value: string
     start: number
     end: number


### PR DESCRIPTION
```ts
  function pushComment(options, array) {
    return function(block, text, start, end, startLoc, endLoc) {
      var comment = {
        type: block ? "Block" : "Line",
        value: text,
        start: start,
        end: end
      };
      if (options.locations)
        { comment.loc = new SourceLocation(this, startLoc, endLoc); }
      if (options.ranges)
        { comment.range = [start, end]; }
      array.push(comment);
    }
  }
```

Since the type is of `Comment` is either `'Block'` or `'Line'`, I suggest declaring the type the same as `estree`'s, i.e. `'Line' | 'Block'` instead of just `string` to make them compatible.