### PR TITLE
Remove passing default options to test262

### DIFF
--- a/bin/run_test262.js
+++ b/bin/run_test262.js
@@ -10,7 +10,7 @@ function loadList(filename) {
 }
 
 run(
-  (content, {sourceType}) => parse(content, {sourceType, ecmaVersion: "latest", allowHashBang: true}),
+  (content, {sourceType}) => parse(content, {sourceType, ecmaVersion: "latest"}),
   {
     testsDirectory: path.dirname(require.resolve("test262/package.json")),
     skip: test => test.attrs.features &&

--- a/bin/run_test262.js
+++ b/bin/run_test262.js
@@ -10,7 +10,7 @@ function loadList(filename) {
 }
 
 run(
-  (content, {sourceType}) => parse(content, {sourceType, ecmaVersion: "latest", allowHashBang: true, allowAwaitOutsideFunction: sourceType === "module"}),
+  (content, {sourceType}) => parse(content, {sourceType, ecmaVersion: "latest", allowHashBang: true}),
   {
     testsDirectory: path.dirname(require.resolve("test262/package.json")),
     skip: test => test.attrs.features &&


### PR DESCRIPTION
also removes the default parameters when testing test262 against "latest" (ES2023)