### PR TITLE
Minor fix

### DIFF
--- a/acorn/src/options.js
+++ b/acorn/src/options.js
@@ -121,7 +121,7 @@ export function getOptions(opts) {
   if (options.allowReserved == null)
     options.allowReserved = options.ecmaVersion < 5
 
-  if (!opts || opts.allowHashBang == null)
+  if (!opts || !Object.prototype.hasOwnProperty.call(opts, "allowHashBang") || opts.allowHashBang == null)
     options.allowHashBang = options.ecmaVersion >= 14
 
   if (isArray(options.onToken)) {


### PR DESCRIPTION
When no options was passed to `parse` the changed line was the cause for a runtime error;

```
/usr/local/opt/node@16/bin/node ./index.js
Since Acorn 8.0.0, options.ecmaVersion is required.
Defaulting to 2020, but this will stop working in the future.
Process exited with code 1
Uncaught TypeError TypeError: Cannot read properties of undefined (reading 'allowHashBang')
    at getOptions (/Code/tmp/jsx_experiment_1/node_modules/acorn/dist/acorn.js:444:14)
    at Parser (/Code/tmp/jsx_experiment_1/node_modules/acorn/dist/acorn.js:501:30)
    at <anonymous> (/Code/tmp/jsx_experiment_1/node_modules/acorn-jsx/index.js:106:10)
    at parse (/Code/tmp/jsx_experiment_1/node_modules/acorn/dist/acorn.js:640:12)
    at <anonymous> (/Code/tmp/jsx_experiment_1/index.js:11:23)
    at Module._compile (internal/modules/cjs/loader:1165:14)
    at Module._extensions..js (internal/modules/cjs/loader:1219:10)
    at Module.load (internal/modules/cjs/loader:1043:32)
    at Module._load (internal/modules/cjs/loader:878:12)
    at executeUserEntryPoint (internal/modules/run_main:81:12)
    at <anonymous> (internal/main/run_main_module:22:47)

```