### PR TITLE
chore: add unsupport feature

### DIFF
--- a/bin/test262.unsupported-features
+++ b/bin/test262.unsupported-features
@@ -2,3 +2,4 @@ decorators
 import-assertions
 regexp-duplicate-named-groups
 regexp-v-flag
+pipeline-operator


### PR DESCRIPTION
As tile, add `pipeline operator` to the unsupport features file.