### PR TITLE
Fixed `.d.mts` content and reexport things correctly

### DIFF
--- a/acorn/dist/acorn.d.mts
+++ b/acorn/dist/acorn.d.mts
@@ -1,2 +1,26 @@
-import * as acorn from "./acorn";
-export = acorn;
+export {
+  Node,
+  Parser,
+  Position,
+  SourceLocation,
+  TokContext,
+  Token,
+  TokenType,
+  defaultOptions,
+  getLineInfo,
+  isIdentifierChar,
+  isIdentifierStart,
+  isNewLine,
+  lineBreak,
+  lineBreakG,
+  parse,
+  parseExpressionAt,
+  tokContexts,
+  tokTypes,
+  tokenizer,
+  version,
+  AbstractToken,
+  Comment,
+  Options,
+  ecmaVersion,
+} from "./acorn.js";


### PR DESCRIPTION
followup to https://github.com/acornjs/acorn/pull/1211

I previously assumed that the content was correct. I got to testing this locally and it turned out that this method of reexporting in the `.d.mts` file **wasn't** correct - perhaps because `acorn.d.ts` has this legacy-ish structure (it's not using modern esm-like syntax):
```ts
export as namespace acorn
export = acorn

declare namespace acorn { /**/ }
```

Either way... I couldn't find a way to reexport things automatically and satisfy TypeScript so I just went for a manual list 🤷 
