### PR TITLE
Add proper `.d.mts` types for `acorn-walk`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@
 /yarn.lock
 !/acorn/dist/acorn.d.ts
 !/acorn/dist/acorn.d.mts
+!/acorn-walk/dist/walk.d.ts
+!/acorn-walk/dist/walk.d.mts

--- a/acorn-walk/dist/walk.d.mts
+++ b/acorn-walk/dist/walk.d.mts
@@ -1,0 +1,1 @@
+export * from './walk.js'


### PR DESCRIPTION
Related to my previous type-related PRs here and the issue recognized [here](https://github.com/microsoft/TypeScript/issues/50762#issuecomment-1528318260)