### PR TITLE
Add remaining Unicode properties for ES2023

### DIFF
--- a/acorn/src/unicode-property-data.js
+++ b/acorn/src/unicode-property-data.js
@@ -30,7 +30,7 @@ const ecma10ScriptValues = ecma9ScriptValues + " Dogra Dogr Gunjala_Gondi Gong H
 const ecma11ScriptValues = ecma10ScriptValues + " Elymaic Elym Nandinagari Nand Nyiakeng_Puachue_Hmong Hmnp Wancho Wcho"
 const ecma12ScriptValues = ecma11ScriptValues + " Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi"
 const ecma13ScriptValues = ecma12ScriptValues + " Cypro_Minoan Cpmn Old_Uyghur Ougr Tangsa Tnsa Toto Vithkuqi Vith"
-const ecma14ScriptValues = ecma13ScriptValues + " Kawi Nag_Mundari Nagm"
+const ecma14ScriptValues = ecma13ScriptValues + " Hrkt Katakana_Or_Hiragana Kawi Nag_Mundari Nagm Unknown Zzzz"
 
 const unicodeScriptValues = {
   9: ecma9ScriptValues,


### PR DESCRIPTION
Unicode properties table now references [PropertyValueAliases.txt](https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt) in ES2023.
This PR adds the remaining Unicode properties that have been added there.

https://github.com/tc39/ecma262/pull/2649
https://unicode.org/Public/UCD/latest/ucd/PropertyValueAliases.txt