### PR TITLE
chore: bump deps, test262

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,15 +33,15 @@
     "test:test262": "node bin/run_test262.js"
   },
   "devDependencies": {
-    "@rollup/plugin-buble": "^1.0.1",
+    "@rollup/plugin-buble": "^1.0.2",
     "@unicode/unicode-15.0.0": "^1.3.1",
-    "eslint": "^8.29.0",
-    "eslint-config-standard": "^17.0.0",
-    "eslint-plugin-import": "^2.26.0",
+    "eslint": "^8.42.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "rollup": "^3.7.4",
-    "test262": "git+https://github.com/tc39/test262.git#dac69563480b9f22709fd49d61a32b3a0513b6b1",
+    "rollup": "^3.25.1",
+    "test262": "git+https://github.com/tc39/test262.git#c5b24c64c3c27544f15e1c18ef274924cff1e32c",
     "test262-parser-runner": "^0.5.0"
   }
 }


### PR DESCRIPTION
@marijnh @ota-meshi  there's some **test262** tests failing (actually halting) regarding the new **regex v flag**.

https://github.com/acornjs/acorn/actions/runs/5269062603/jobs/9526644346

related PR: https://github.com/tc39/test262/pull/3820