### PR TITLE
Remove checkPatternExport dead code

### DIFF
--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -949,8 +949,6 @@ pp.checkPatternExport = function(exports, pat) {
     this.checkPatternExport(exports, pat.left)
   else if (type === "RestElement")
     this.checkPatternExport(exports, pat.argument)
-  else if (type === "ParenthesizedExpression")
-    this.checkPatternExport(exports, pat.expression)
 }
 
 pp.checkVariableExport = function(exports, decls) {


### PR DESCRIPTION
`checkPatternExport()` has a branch to detected `ParenthesizedExpression`. This expression can never occur in the relevant portions of a pattern export.

```js
pp.checkPatternExport = function(exports, pat) {
  let type = pat.type
  ..
  else if (type === "ParenthesizedExpression")
    this.checkPatternExport(exports, pat.expression)
}
```

This patch removes the `ParenthesizedExpression` branch from `checkPatternExport`. All tests pass, including test262. Closes #1229.