### PR TITLE
minor walk tweak

### DIFF
--- a/acorn-walk/src/index.js
+++ b/acorn-walk/src/index.js
@@ -19,9 +19,9 @@
 export function simple(node, visitors, baseVisitor, state, override) {
   if (!baseVisitor) baseVisitor = base
   ;(function c(node, st, override) {
-    let type = override || node.type, found = visitors[type]
+    let type = override || node.type
     baseVisitor[type](node, st, c)
-    if (found) found(node, st)
+    if (visitors[type]) visitors[type](node, st)
   })(node, state, override)
 }
 
@@ -32,11 +32,11 @@ export function ancestor(node, visitors, baseVisitor, state, override) {
   let ancestors = []
   if (!baseVisitor) baseVisitor = base
   ;(function c(node, st, override) {
-    let type = override || node.type, found = visitors[type]
+    let type = override || node.type
     let isNew = node !== ancestors[ancestors.length - 1]
     if (isNew) ancestors.push(node)
     baseVisitor[type](node, st, c)
-    if (found) found(node, st || ancestors, ancestors)
+    if (visitors[type]) visitors[type](node, st || ancestors, ancestors)
     if (isNew) ancestors.pop()
   })(node, state, override)
 }

--- a/acorn-walk/src/walk.d.ts
+++ b/acorn-walk/src/walk.d.ts
@@ -169,4 +169,7 @@ export function findNodeAround<TState>(
  */
 export const findNodeAfter: typeof findNodeAround
 
-export const base: RecursiveVisitors<any>
+export class Base<TState> {}
+export interface Base<TState> extends RecursiveVisitors<TState> {}
+
+export const base: Base<any>


### PR DESCRIPTION
core idea was to make```visitors``` keep their ```this``` context, so code below could work
```js
class Crawler {
    importNodes = [];
    ImportDeclaration(node) {
        this.importNodes.push(node);
    }
    
}

const crawler = new Crawler();
walk.simple(ast, crawler);
const { importNodes } = crawler;
```
alos made ```base``` a class instance, so overriding its method is easier