### PR TITLE
Fix minor ParenthesizedExpression-related issues

### DIFF
--- a/bin/run_test262.js
+++ b/bin/run_test262.js
@@ -10,7 +10,7 @@ function loadList(filename) {
 }
 
 run(
-  (content, {sourceType}) => parse(content, {sourceType, ecmaVersion: "latest"}),
+  (content, {sourceType}) => parse(content, {sourceType, ecmaVersion: "latest", preserveParens: true}),
   {
     testsDirectory: path.dirname(require.resolve("test262/package.json")),
     skip: test => test.attrs.features &&


### PR DESCRIPTION
If you run the test262 test suite with the `preserveParens` option enabled, you'll get some failing tests.

Apparently, in some edge cases the parser is not prepared to deal with `ParenthesizedExpression`s. This PR aims to fix these cases.