### PR TITLE
Fix minor line terminator/line number tracking issues

### DIFF
--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -706,7 +706,7 @@ pp.parseTemplateElement = function({isTagged}) {
       this.raiseRecoverable(this.start, "Bad escape sequence in untagged template literal")
     }
     elem.value = {
-      raw: this.value,
+      raw: this.value.replace(/\r\n?/g, "\n"),
       cooked: null
     }
   } else {

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -42,7 +42,7 @@ pp.isLet = function(context) {
   // Statement) is allowed here. If context is not empty then only a Statement
   // is allowed. However, `let [` is an explicit negative lookahead for
   // ExpressionStatement, so special-case it first.
-  if (nextCh === 91 || nextCh === 92) return true // '[', '/'
+  if (nextCh === 91 || nextCh === 92) return true // '[', '\'
   if (context) return false
 
   if (nextCh === 123 || nextCh > 0xd7ff && nextCh < 0xdc00) return true // '{', astral

--- a/acorn/src/tokenize.js
+++ b/acorn/src/tokenize.js
@@ -677,7 +677,7 @@ pp.readInvalidTemplateToken = function() {
       return this.finishToken(tt.invalidTemplate, this.input.slice(this.start, this.pos))
 
     case "\r":
-      if (this.input[this.pos] + 1 === "\n") ++this.pos
+      if (this.input[this.pos + 1] === "\n") ++this.pos
       // fall through
     case "\n": case "\u2028": case "\u2029":
       ++this.curLine

--- a/acorn/src/tokenize.js
+++ b/acorn/src/tokenize.js
@@ -745,6 +745,7 @@ pp.readEscapedChar = function(inTemplate) {
     if (isNewLine(ch)) {
       // Unicode new line characters after \ get removed from output in both
       // template literals and strings
+      if (this.options.locations) { this.lineStart = this.pos; ++this.curLine }
       return ""
     }
     return String.fromCharCode(ch)

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -816,23 +816,23 @@ test("`\\n\\r\\b\\v\\t\\f\\\n\\\r\n\\\u2028\\\u2029`", {
         tail: true,
         loc: {
           start: {line: 1, column: 1},
-          end: {line: 3, column: 4}
+          end: {line: 5, column: 0}
         }
       }],
       expressions: [],
       loc: {
         start: {line: 1, column: 0},
-        end: {line: 3, column: 5}
+        end: {line: 5, column: 1}
       }
     },
     loc: {
       start: {line: 1, column: 0},
-      end: {line: 3, column: 5}
+      end: {line: 5, column: 1}
     }
   }],
   loc: {
     start: {line: 1, column: 0},
-    end: {line: 3, column: 5}
+    end: {line: 5, column: 1}
   }
 }, {
   ecmaVersion: 6,

--- a/test/tests.js
+++ b/test/tests.js
@@ -6928,8 +6928,8 @@ test("\"Hello\\\u2028world\"", {
             column: 0
           },
           end: {
-            line: 1,
-            column: 14
+            line: 2,
+            column: 6
           }
         }
       },
@@ -6939,8 +6939,8 @@ test("\"Hello\\\u2028world\"", {
           column: 0
         },
         end: {
-          line: 1,
-          column: 14
+          line: 2,
+          column: 6
         }
       }
     }
@@ -6951,8 +6951,8 @@ test("\"Hello\\\u2028world\"", {
       column: 0
     },
     end: {
-      line: 1,
-      column: 14
+      line: 2,
+      column: 6
     }
   }
 });
@@ -6972,8 +6972,8 @@ test("\"Hello\\\u2029world\"", {
             column: 0
           },
           end: {
-            line: 1,
-            column: 14
+            line: 2,
+            column: 6
           }
         }
       },
@@ -6983,8 +6983,8 @@ test("\"Hello\\\u2029world\"", {
           column: 0
         },
         end: {
-          line: 1,
-          column: 14
+          line: 2,
+          column: 6
         }
       }
     }
@@ -6995,8 +6995,8 @@ test("\"Hello\\\u2029world\"", {
       column: 0
     },
     end: {
-      line: 1,
-      column: 14
+      line: 2,
+      column: 6
     }
   }
 });


### PR DESCRIPTION
Fixes some minor issues with template/string literals and line terminators:
* It seems that `CR` and `CR LF` line terminators should be normalized in raw strings of invalid tagged template literals, just like in the case of normal template literals. At least, according to my tests, V8 and Firefox JS engines do this. (I couldn't find much info about this in the spec though). For example, check the output of the following expression: ``eval('(s => s.raw[0])`t\r\nc:\\\rx`')``.
* Another issue addressed is `LS`/`PS` line terminators in string and template literals in [`LineContinuation`](https://tc39.es/ecma262/#prod-LineContinuation) positions. The token value is produced correctly, however the line number was not increased in these cases. I'm not completely sure about this though, but stepping the line number counter seems the consistent behavior. At least, I couldn't find anything in the ECMA spec that says `LS`/`PS` should be treated in a special way in `LineContinuation` position w.r.t. line number tracking. But please correct me if I'm missing something here.