### PR TITLE
Handle line terminators when looking for directives

### DIFF
--- a/acorn/src/parseutil.js
+++ b/acorn/src/parseutil.js
@@ -6,7 +6,7 @@ const pp = Parser.prototype
 
 // ## Parser utilities
 
-const literal = /^(?:'((?:\\.|[^'\\])*?)'|"((?:\\.|[^"\\])*?)")/
+const literal = /^(?:'((?:\\.|[^'\\])*?)'|"((?:\\.|[^"\\])*?)")/s
 pp.strictDirective = function(start) {
   if (this.options.ecmaVersion < 5) return false
   for (;;) {

--- a/test/tests-directive.js
+++ b/test/tests-directive.js
@@ -2,6 +2,7 @@
 if (typeof exports !== "undefined") {
   var driver = require("./driver.js");
   var test = driver.test;
+  var testFail = driver.testFail;
 }
 
 //------------------------------------------------------------------------
@@ -1384,3 +1385,8 @@ test("(a = () => { \"use strict\"; foo }) => { \"use strict\" }", {
     }
   ]
 }, { ecmaVersion: 6 })
+
+testFail(
+  "function invalid() { \"\\7\\\n\"; \"use strict\"; }",
+  "Octal literal in strict mode (1:22)",
+  { ecmaVersion: 6 })


### PR DESCRIPTION
When looking for directives, handle the case that previous strings can have line terminator escape sequences.