### PR TITLE
Fix parsing of an "async of" edge case in for loop 

### DIFF
--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -237,7 +237,9 @@ pp.parseForStatement = function(node) {
   let startsWithLet = this.isContextual("let"), isForOf = false
   let containsEsc = this.containsEsc
   let refDestructuringErrors = new DestructuringErrors
-  let init = this.parseExpression(awaitAt > -1 ? "await" : true, refDestructuringErrors)
+  let init = awaitAt > -1
+    ? this.parseExprSubscripts(refDestructuringErrors, "await")
+    : this.parseExpression(true, refDestructuringErrors)
   if (this.type === tt._in || (isForOf = this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
     if (awaitAt > -1) { // implies `ecmaVersion >= 9` (see declaration of awaitAt)
       if (this.type === tt._in) this.unexpected(awaitAt)

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -235,13 +235,16 @@ pp.parseForStatement = function(node) {
     return this.parseFor(node, init)
   }
   let startsWithLet = this.isContextual("let"), isForOf = false
+  let containsEsc = this.containsEsc
   let refDestructuringErrors = new DestructuringErrors
   let init = this.parseExpression(awaitAt > -1 ? "await" : true, refDestructuringErrors)
   if (this.type === tt._in || (isForOf = this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
-    if (this.options.ecmaVersion >= 9) {
-      if (this.type === tt._in) {
-        if (awaitAt > -1) this.unexpected(awaitAt)
-      } else node.await = awaitAt > -1
+    if (awaitAt > -1) { // implies `ecmaVersion >= 9` (see declaration of awaitAt)
+      if (this.type === tt._in) this.unexpected(awaitAt)
+      node.await = true
+    } else if (isForOf && this.options.ecmaVersion >= 8) {
+      if (!containsEsc && init.type === "Identifier" && init.name === "async") this.unexpected()
+      else if (this.options.ecmaVersion >= 9) node.await = false
     }
     if (startsWithLet && isForOf) this.raise(init.start, "The left-hand side of a for-of loop may not start with 'let'.")
     this.toAssignable(init, false, refDestructuringErrors)

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -237,6 +237,7 @@ pp.parseForStatement = function(node) {
   let startsWithLet = this.isContextual("let"), isForOf = false
   let containsEsc = this.containsEsc
   let refDestructuringErrors = new DestructuringErrors
+  let initPos = this.start
   let init = awaitAt > -1
     ? this.parseExprSubscripts(refDestructuringErrors, "await")
     : this.parseExpression(true, refDestructuringErrors)
@@ -245,7 +246,7 @@ pp.parseForStatement = function(node) {
       if (this.type === tt._in) this.unexpected(awaitAt)
       node.await = true
     } else if (isForOf && this.options.ecmaVersion >= 8) {
-      if (!containsEsc && init.type === "Identifier" && init.name === "async") this.unexpected()
+      if (init.start === initPos && !containsEsc && init.type === "Identifier" && init.name === "async") this.unexpected()
       else if (this.options.ecmaVersion >= 9) node.await = false
     }
     if (startsWithLet && isForOf) this.raise(init.start, "The left-hand side of a for-of loop may not start with 'let'.")

--- a/test/tests-async-iteration.js
+++ b/test/tests-async-iteration.js
@@ -1998,3 +1998,5 @@ test("async () => { for await (async of []); }", {}, {ecmaVersion: 9})
 test("for (async of => {}; i < 10; ++i) {}", {}, {ecmaVersion: 9})
 testFail("for (async of [1]) {}", "Unexpected token (1:14)", {ecmaVersion: 9})
 
+testFail("async () => { for (async\nof []); }", "Unexpected token (2:0)", {ecmaVersion: 9})
+testFail("async () => { for (async of\n[]); }", "Unexpected token (2:0)", {ecmaVersion: 9})

--- a/test/tests-async-iteration.js
+++ b/test/tests-async-iteration.js
@@ -2000,3 +2000,4 @@ testFail("for (async of [1]) {}", "Unexpected token (1:14)", {ecmaVersion: 9})
 
 testFail("async () => { for (async\nof []); }", "Unexpected token (2:0)", {ecmaVersion: 9})
 testFail("async () => { for (async of\n[]); }", "Unexpected token (2:0)", {ecmaVersion: 9})
+test("for ((async) of [7]);", {}, {ecmaVersion: 9})


### PR DESCRIPTION
The following edge case of for loops should result in syntax error but is accepted currently:

```js
async () => { for (async
of []); }
```

This PR makes an attempt at fixing this issue.

Also, suggests a minor improvement to parsing of for statements:

As far as I can tell based on the [spec](https://262.ecma-international.org/13.0/#prod-ForInOfStatement), we can "take a shortcut" in the case of for-await-of loops. Once we read "for await", the initializer of the for statement is no longer ambiguous (since we know that it can't be a for(;;) loop), that is, the initializer part will be a *LeftHandSideExpression* (unless it's a variable declaration). So, we don't need to parse a full expression using `parseExpression`, `parseExprSubscripts` is enough - if my understanding of acorn's inner workings is correct.

Also V8 seems to take this shortcut: just check the error reported for e.g. `async() => { for await (x = 1 of []); }`