### PR TITLE
Fix scope-related regressions and await vs. class property initializers issue

### DIFF
--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -1043,7 +1043,7 @@ pp.checkUnreserved = function({start, end, name}) {
     this.raiseRecoverable(start, "Cannot use 'yield' as identifier inside a generator")
   if (this.inAsync && name === "await")
     this.raiseRecoverable(start, "Cannot use 'await' as identifier inside an async function")
-  if (this.currentScope().inClassFieldInit && name === "arguments")
+  if (this.currentThisScope().inClassFieldInit && name === "arguments")
     this.raiseRecoverable(start, "Cannot use 'arguments' in class field initializer")
   if (this.inClassStaticBlock && (name === "arguments" || name === "await"))
     this.raise(start, `Cannot use ${name} in class static initialization block`)

--- a/acorn/src/state.js
+++ b/acorn/src/state.js
@@ -104,13 +104,14 @@ export class Parser {
   get inAsync() { return (this.currentVarScope().flags & SCOPE_ASYNC) > 0 && !this.currentVarScope().inClassFieldInit }
 
   get canAwait() {
-    if (this.currentThisScope().inClassFieldInit) return false
-    for (let i = this.scopeStack.length - 1; i >= 0; i--) {
-      let scope = this.scopeStack[i]
-      if (scope.flags & SCOPE_CLASS_STATIC_BLOCK) return false
-      if (scope.flags & SCOPE_FUNCTION) return (scope.flags & SCOPE_ASYNC) > 0
+    const scope = this.currentVarScope()
+    if (scope.flags & SCOPE_FUNCTION) {
+      return (scope.flags & SCOPE_ASYNC) && !scope.inClassFieldInit
     }
-    return (this.inModule && this.options.ecmaVersion >= 13) || this.options.allowAwaitOutsideFunction
+    if (scope.flags & SCOPE_TOP) {
+      return ((this.inModule && this.options.ecmaVersion >= 13) || this.options.allowAwaitOutsideFunction) && !scope.inClassFieldInit
+    }
+    return false
   }
 
   get allowSuper() {

--- a/acorn/src/state.js
+++ b/acorn/src/state.js
@@ -99,14 +99,15 @@ export class Parser {
 
   get inFunction() { return (this.currentVarScope().flags & SCOPE_FUNCTION) > 0 }
 
-  get inGenerator() { return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0 && !this.currentScope().inClassFieldInit }
+  get inGenerator() { return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0 && !this.currentVarScope().inClassFieldInit }
 
-  get inAsync() { return (this.currentScope().flags & SCOPE_ASYNC) > 0 && !this.currentScope().inClassFieldInit }
+  get inAsync() { return (this.currentVarScope().flags & SCOPE_ASYNC) > 0 && !this.currentVarScope().inClassFieldInit }
 
   get canAwait() {
+    if (this.currentThisScope().inClassFieldInit) return false
     for (let i = this.scopeStack.length - 1; i >= 0; i--) {
       let scope = this.scopeStack[i]
-      if (scope.flags & SCOPE_CLASS_STATIC_BLOCK || scope.inClassFieldInit) return false
+      if (scope.flags & SCOPE_CLASS_STATIC_BLOCK) return false
       if (scope.flags & SCOPE_FUNCTION) return (scope.flags & SCOPE_ASYNC) > 0
     }
     return (this.inModule && this.options.ecmaVersion >= 13) || this.options.allowAwaitOutsideFunction
@@ -122,8 +123,8 @@ export class Parser {
   get treatFunctionsAsVar() { return this.treatFunctionsAsVarInScope(this.currentScope()) }
 
   get allowNewDotTarget() {
-    const {flags} = this.currentThisScope()
-    return (flags & (SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK)) > 0 || this.currentScope().inClassFieldInit
+    const {flags, inClassFieldInit} = this.currentThisScope()
+    return (flags & (SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK)) > 0 || inClassFieldInit
   }
 
   get inClassStaticBlock() {

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -742,11 +742,13 @@ pp.parseClassField = function(field) {
 
   if (this.eat(tt.eq)) {
     // To raise SyntaxError if 'arguments' exists in the initializer.
-    const scope = this.currentThisScope()
-    const inClassFieldInit = scope.inClassFieldInit
-    scope.inClassFieldInit = true
+    const thisScope = this.currentThisScope(), varScope = this.currentVarScope()
+    const thisScopeInClassFieldInit = thisScope.inClassFieldInit
+    const varScopeInClassFieldInit = varScope.inClassFieldInit
+    thisScope.inClassFieldInit = varScope.inClassFieldInit = true
     field.value = this.parseMaybeAssign()
-    scope.inClassFieldInit = inClassFieldInit
+    thisScope.inClassFieldInit = thisScopeInClassFieldInit
+    varScope.inClassFieldInit = varScopeInClassFieldInit
   } else {
     field.value = null
   }

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -742,7 +742,7 @@ pp.parseClassField = function(field) {
 
   if (this.eat(tt.eq)) {
     // To raise SyntaxError if 'arguments' exists in the initializer.
-    const scope = this.currentScope()
+    const scope = this.currentThisScope()
     const inClassFieldInit = scope.inClassFieldInit
     scope.inClassFieldInit = true
     field.value = this.parseMaybeAssign()


### PR DESCRIPTION
This PR makes an attempt at solving #1338, including the regressions introduced by https://github.com/acornjs/acorn/commit/9e365f71f339360df3d3b74b3df698a4483439b2

The main idea is to set `inClassFieldInit` in both `this` and var scope when parsing the initializer part of a class property.

This way it seems to work - or at least I haven't been able to construct code that breaks it yet. Regardless, the whole approach to tracking class property initializer context doesn't feel too clean...

What do you think? Do you see an issue with this approach?