### PR TITLE
fix acorn-walk docs typo

### DIFF
--- a/acorn-walk/README.md
+++ b/acorn-walk/README.md
@@ -107,7 +107,7 @@ walk.full(acorn.parse("1 + 1"), node => {
 
 **findNodeAt**`(node, start, end, test, base, state)` tries to locate
 a node in a tree at the given start and/or end offsets, which
-satisfies the predicate `test`. `start` and `end` can be either `null`
+satisfies the predicate `test`. `start` and `end` can be either `undefined`
 (as wildcard) or a number. `test` may be a string (indicating a node
 type) or a function that takes `(nodeType, node)` arguments and
 returns a boolean indicating whether this node is interesting. `base`


### PR DESCRIPTION
In the acorn-walk readme, we say that `findNodeAt`'s `start` and `end` can be `null`, but our TS type definitions say `undefined` instead. This makes the readme match the TS types.

https://github.com/acornjs/acorn/blob/3221fa54f9dea30338228b97210c4f1fd332652d/acorn-walk/src/walk.d.ts#L142-L145

Interestingly, we actually _do_ explicitly check for `null` in the code, but we're doing double-equals rather than strict equality, so `undefined == null`.

https://github.com/acornjs/acorn/blob/3221fa54f9dea30338228b97210c4f1fd332652d/acorn-walk/src/index.js#L110-L114