### PR TITLE
feat: Include file name in `SyntaxError` if present

### DIFF
--- a/acorn/src/location.js
+++ b/acorn/src/location.js
@@ -11,9 +11,9 @@ const pp = Parser.prototype
 
 pp.raise = function(pos, message) {
   let loc = getLineInfo(this.input, pos)
-  message += ` (${loc.line}:${loc.column})`
+  message += " (" + loc.line + ":" + loc.column + ")"
   if (this.sourceFile) {
-    message += ` in ${this.sourceFile}`
+    message += " in " + this.sourceFile
   }
   let err = new SyntaxError(message)
   err.pos = pos; err.loc = loc; err.raisedAt = this.pos

--- a/acorn/src/location.js
+++ b/acorn/src/location.js
@@ -11,7 +11,10 @@ const pp = Parser.prototype
 
 pp.raise = function(pos, message) {
   let loc = getLineInfo(this.input, pos)
-  message += " (" + loc.line + ":" + loc.column + ")"
+  message += ` (${loc.line}:${loc.column})`
+  if (this.sourceFile) {
+    message += ` in ${this.sourceFile}`
+  }
   let err = new SyntaxError(message)
   err.pos = pos; err.loc = loc; err.raisedAt = this.pos
   throw err


### PR DESCRIPTION
While using nuxt, I encountered this mysterious error:
```
[3:05:39 PM]  ERROR  [unhandledRejection] Unexpected token (2:12) 
```
This change should make it easier to identify the source of the issue.