### PR TITLE
Consistent field order in `Property` in tests

### DIFF
--- a/test/tests-async-iteration.js
+++ b/test/tests-async-iteration.js
@@ -415,7 +415,6 @@ test("obj = { async f() { for await (x of xs); } }", {
                 "end": 15,
                 "name": "f"
               },
-              "kind": "init",
               "value": {
                 "type": "FunctionExpression",
                 "start": 15,
@@ -455,7 +454,8 @@ test("obj = { async f() { for await (x of xs); } }", {
                     }
                   ]
                 }
-              }
+              },
+              "kind": "init"
             }
           ]
         }
@@ -846,7 +846,6 @@ test("obj = { async* f() { await a; yield b; } }", {
                 "end": 16,
                 "name": "f"
               },
-              "kind": "init",
               "value": {
                 "type": "FunctionExpression",
                 "start": 16,
@@ -896,7 +895,8 @@ test("obj = { async* f() { await a; yield b; } }", {
                     }
                   ]
                 }
-              }
+              },
+              "kind": "init"
             }
           ]
         }
@@ -1249,7 +1249,6 @@ test("var gen = { async *method() {} }", {
                   "end": 25,
                   "name": "method"
                 },
-                "kind": "init",
                 "value": {
                   "type": "FunctionExpression",
                   "start": 25,
@@ -1265,7 +1264,8 @@ test("var gen = { async *method() {} }", {
                     "start": 28,
                     "type": "BlockStatement"
                   }
-                }
+                },
+                "kind": "init"
               }
             ]
           }
@@ -1360,7 +1360,6 @@ test("var C = class { async *method() {} }", {}, { "ecmaVersion": 9 })
 //                   "end": 25,
 //                   "name": "method"
 //                 },
-//                 "kind": "init",
 //                 "value": {
 //                   "type": "FunctionExpression",
 //                   "start": 25,
@@ -1429,7 +1428,8 @@ test("var C = class { async *method() {} }", {}, { "ecmaVersion": 9 })
 //                       }
 //                     ]
 //                   }
-//                 }
+//                 },
+//                 "kind": "init"
 //               }
 //             ]
 //           }
@@ -1565,7 +1565,6 @@ test("var C = class { async *method() {} }", {}, { "ecmaVersion": 9 })
 //                   "end": 25,
 //                   "name": "method"
 //                 },
-//                 "kind": "init",
 //                 "value": {
 //                   "type": "FunctionExpression",
 //                   "start": 25,
@@ -1634,7 +1633,8 @@ test("var C = class { async *method() {} }", {}, { "ecmaVersion": 9 })
 //                       }
 //                     ]
 //                   }
-//                 }
+//                 },
+//                 "kind": "init"
 //               }
 //             ]
 //           }
@@ -1770,7 +1770,6 @@ test("var C = class { async *method() {} }", {}, { "ecmaVersion": 9 })
 //                   "end": 25,
 //                   "name": "method"
 //                 },
-//                 "kind": "init",
 //                 "value": {
 //                   "type": "FunctionExpression",
 //                   "start": 25,
@@ -1861,7 +1860,8 @@ test("var C = class { async *method() {} }", {}, { "ecmaVersion": 9 })
 //                       }
 //                     ]
 //                   }
-//                 }
+//                 },
+//                 "kind": "init"
 //               }
 //             ]
 //           }

--- a/test/tests-asyncawait.js
+++ b/test/tests-asyncawait.js
@@ -559,7 +559,6 @@ test("async ({a = b}) => a", {
                                     "end": 9,
                                     "name": "a"
                                 },
-                                "kind": "init",
                                 "value": {
                                     "type": "AssignmentPattern",
                                     "start": 8,
@@ -576,7 +575,8 @@ test("async ({a = b}) => a", {
                                         "end": 13,
                                         "name": "b"
                                     }
-                                }
+                                },
+                                "kind": "init"
                             }
                         ]
                     }
@@ -915,7 +915,6 @@ test("({foo() { }})", {
                             "end": 5,
                             "name": "foo"
                         },
-                        "kind": "init",
                         "value": {
                             "type": "FunctionExpression",
                             "start": 5,
@@ -931,7 +930,8 @@ test("({foo() { }})", {
                                 "end": 11,
                                 "body": []
                             }
-                        }
+                        },
+                        "kind": "init"
                     }
                 ]
             }
@@ -968,7 +968,6 @@ test("({async foo() { }})", {
                             "end": 11,
                             "name": "foo"
                         },
-                        "kind": "init",
                         "value": {
                             "type": "FunctionExpression",
                             "start": 11,
@@ -984,7 +983,8 @@ test("({async foo() { }})", {
                                 "end": 17,
                                 "body": []
                             }
-                        }
+                        },
+                        "kind": "init"
                     }
                 ]
             }
@@ -1021,7 +1021,6 @@ test("({async() { }})", {
                             "end": 7,
                             "name": "async"
                         },
-                        "kind": "init",
                         "value": {
                             "type": "FunctionExpression",
                             "start": 7,
@@ -1037,7 +1036,8 @@ test("({async() { }})", {
                                 "end": 13,
                                 "body": []
                             }
-                        }
+                        },
+                        "kind": "init"
                     }
                 ]
             }
@@ -1082,7 +1082,6 @@ test("({async await() { }})", {
                             "end": 13,
                             "name": "await"
                         },
-                        "kind": "init",
                         "value": {
                             "type": "FunctionExpression",
                             "start": 13,
@@ -1098,7 +1097,8 @@ test("({async await() { }})", {
                                 "end": 19,
                                 "body": []
                             }
-                        }
+                        },
+                        "kind": "init"
                     }
                 ]
             }
@@ -1875,7 +1875,6 @@ test("({async foo(a) { await a }})", {
                             "end": 11,
                             "name": "foo"
                         },
-                        "kind": "init",
                         "value": {
                             "type": "FunctionExpression",
                             "start": 11,
@@ -1915,7 +1914,8 @@ test("({async foo(a) { await a }})", {
                                     }
                                 ]
                             }
-                        }
+                        },
+                        "kind": "init"
                     }
                 ]
             }
@@ -2400,7 +2400,6 @@ test("async function foo(a = {async bar() { await b }}) {}", {
                   "end": 33,
                   "name": "bar"
                 },
-                "kind": "init",
                 "value": {
                   "type": "FunctionExpression",
                   "start": 33,
@@ -2433,7 +2432,8 @@ test("async function foo(a = {async bar() { await b }}) {}", {
                       }
                     ]
                   }
-                }
+                },
+                "kind": "init"
               }
             ]
           }
@@ -2664,7 +2664,6 @@ test("async function wrap() {\n({a = await b} = obj)\n}", {
                       "end": 27,
                       "name": "a"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "AssignmentPattern",
                       "start": 26,
@@ -2686,7 +2685,8 @@ test("async function wrap() {\n({a = await b} = obj)\n}", {
                           "name": "b"
                         }
                       }
-                    }
+                    },
+                    "kind": "init"
                   }
                 ]
               },
@@ -2829,7 +2829,6 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                       "end": 8,
                       "name": "w"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "AssignmentPattern",
                       "start": 7,
@@ -2852,7 +2851,8 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                         },
                         "arguments": []
                       }
-                    }
+                    },
+                    "kind": "init"
                   },
                   {
                     "type": "Property",
@@ -2867,7 +2867,6 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                       "end": 23,
                       "name": "x"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "AssignmentPattern",
                       "start": 22,
@@ -2890,7 +2889,8 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                         },
                         "arguments": []
                       }
-                    }
+                    },
+                    "kind": "init"
                   },
                   {
                     "type": "Property",
@@ -2905,7 +2905,6 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                       "end": 38,
                       "name": "y"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "AssignmentPattern",
                       "start": 37,
@@ -2928,7 +2927,8 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                         },
                         "arguments": []
                       }
-                    }
+                    },
+                    "kind": "init"
                   },
                   {
                     "type": "Property",
@@ -2943,7 +2943,6 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                       "end": 53,
                       "name": "z"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "AssignmentPattern",
                       "start": 52,
@@ -2966,7 +2965,8 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                         },
                         "arguments": []
                       }
-                    }
+                    },
+                    "kind": "init"
                   }
                 ]
               },
@@ -2988,14 +2988,14 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                       "end": 73,
                       "name": "w"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "Literal",
                       "start": 75,
                       "end": 79,
                       "value": null,
                       "raw": "null"
-                    }
+                    },
+                    "kind": "init"
                   },
                   {
                     "type": "Property",
@@ -3010,14 +3010,14 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                       "end": 82,
                       "name": "x"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "Literal",
                       "start": 84,
                       "end": 85,
                       "value": 0,
                       "raw": "0"
-                    }
+                    },
+                    "kind": "init"
                   },
                   {
                     "type": "Property",
@@ -3032,14 +3032,14 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                       "end": 88,
                       "name": "y"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "Literal",
                       "start": 90,
                       "end": 95,
                       "value": false,
                       "raw": "false"
-                    }
+                    },
+                    "kind": "init"
                   },
                   {
                     "type": "Property",
@@ -3054,14 +3054,14 @@ test("f = ({ w = counter(), x = counter(), y = counter(), z = counter() } = { w:
                       "end": 98,
                       "name": "z"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "Literal",
                       "start": 100,
                       "end": 102,
                       "value": "",
                       "raw": "''"
-                    }
+                    },
+                    "kind": "init"
                   }
                 ]
               }
@@ -3142,13 +3142,13 @@ test(
                 "end": 7,
                 "name": "async"
               },
-              "kind": "init",
               "value": {
                 "type": "Identifier",
                 "start": 2,
                 "end": 7,
                 "name": "async"
-              }
+              },
+              "kind": "init"
             }
           ]
         }
@@ -3187,13 +3187,13 @@ test(
                 "end": 7,
                 "name": "async"
               },
-              "kind": "init",
               "value": {
                 "type": "Identifier",
                 "start": 2,
                 "end": 7,
                 "name": "async"
-              }
+              },
+              "kind": "init"
             },
             {
               "type": "Property",
@@ -3208,13 +3208,13 @@ test(
                 "end": 12,
                 "name": "foo"
               },
-              "kind": "init",
               "value": {
                 "type": "Identifier",
                 "start": 9,
                 "end": 12,
                 "name": "foo"
-              }
+              },
+              "kind": "init"
             }
           ]
         }
@@ -3258,7 +3258,6 @@ test(
                   "end": 7,
                   "name": "async"
                 },
-                "kind": "init",
                 "value": {
                   "type": "AssignmentPattern",
                   "start": 2,
@@ -3276,7 +3275,8 @@ test(
                     "value": 0,
                     "raw": "0"
                   }
-                }
+                },
+                "kind": "init"
               }
             ]
           },
@@ -3325,7 +3325,6 @@ test(
                 "value": "foo",
                 "raw": "\"foo\""
               },
-              "kind": "init",
               "value": {
                 "type": "FunctionExpression",
                 "start": 13,
@@ -3341,7 +3340,8 @@ test(
                   "end": 17,
                   "body": []
                 }
-              }
+              },
+              "kind": "init"
             }
           ]
         }
@@ -3381,7 +3381,6 @@ test(
                 "value": "foo",
                 "raw": "'foo'"
               },
-              "kind": "init",
               "value": {
                 "type": "FunctionExpression",
                 "start": 13,
@@ -3397,7 +3396,8 @@ test(
                   "end": 17,
                   "body": []
                 }
-              }
+              },
+              "kind": "init"
             }
           ]
         }
@@ -3437,7 +3437,6 @@ test(
                 "value": 100,
                 "raw": "100"
               },
-              "kind": "init",
               "value": {
                 "type": "FunctionExpression",
                 "start": 11,
@@ -3453,7 +3452,8 @@ test(
                   "end": 15,
                   "body": []
                 }
-              }
+              },
+              "kind": "init"
             }
           ]
         }
@@ -3492,7 +3492,6 @@ test(
                 "end": 12,
                 "name": "foo"
               },
-              "kind": "init",
               "value": {
                 "type": "FunctionExpression",
                 "start": 13,
@@ -3508,7 +3507,8 @@ test(
                   "end": 17,
                   "body": []
                 }
-              }
+              },
+              "kind": "init"
             }
           ]
         }

--- a/test/tests-directive.js
+++ b/test/tests-directive.js
@@ -551,7 +551,6 @@ test("({ wrap() { \"use strict\"; foo } })", {
               "end": 7,
               "name": "wrap"
             },
-            "kind": "init",
             "value": {
               "type": "FunctionExpression",
               "start": 7,
@@ -592,7 +591,8 @@ test("({ wrap() { \"use strict\"; foo } })", {
                   }
                 ]
               }
-            }
+            },
+            "kind": "init"
           }
         ]
       },

--- a/test/tests-harmony.js
+++ b/test/tests-harmony.js
@@ -14740,7 +14740,9 @@ test("let {x} = y", {
             "start": 4,
             "properties": [
               {
+                "type": "Property",
                 "start": 5,
+                "end": 6,
                 "method": false,
                 "shorthand": true,
                 "computed": false,
@@ -14750,15 +14752,13 @@ test("let {x} = y", {
                   "type": "Identifier",
                   "end": 6
                 },
-                "kind": "init",
                 "value": {
                   "start": 5,
                   "name": "x",
                   "type": "Identifier",
                   "end": 6
                 },
-                "type": "Property",
-                "end": 6
+                "kind": "init"
               }
             ],
             "type": "ObjectPattern",
@@ -15181,13 +15181,13 @@ test("function foo() { return {arguments} }", {
                                         "end": 34,
                                         "name": "arguments"
                                     },
-                                    "kind": "init",
                                     "value": {
                                         "type": "Identifier",
                                         "start": 25,
                                         "end": 34,
                                         "name": "arguments"
-                                    }
+                                    },
+                                    "kind": "init"
                                 }
                             ]
                         }
@@ -15243,13 +15243,13 @@ test("function foo() { return {eval} }", {
                                         "end": 29,
                                         "name": "eval"
                                     },
-                                    "kind": "init",
                                     "value": {
                                         "type": "Identifier",
                                         "start": 25,
                                         "end": 29,
                                         "name": "eval"
-                                    }
+                                    },
+                                    "kind": "init"
                                 }
                             ]
                         }
@@ -15317,13 +15317,13 @@ test("function foo() { 'use strict'; return {arguments} }", {
                                         "end": 48,
                                         "name": "arguments"
                                     },
-                                    "kind": "init",
                                     "value": {
                                         "type": "Identifier",
                                         "start": 39,
                                         "end": 48,
                                         "name": "arguments"
-                                    }
+                                    },
+                                    "kind": "init"
                                 }
                             ]
                         }
@@ -15391,13 +15391,13 @@ test("function foo() { 'use strict'; return {eval} }", {
                                         "end": 43,
                                         "name": "eval"
                                     },
-                                    "kind": "init",
                                     "value": {
                                         "type": "Identifier",
                                         "start": 39,
                                         "end": 43,
                                         "name": "eval"
-                                    }
+                                    },
+                                    "kind": "init"
                                 }
                             ]
                         }
@@ -15454,13 +15454,13 @@ test("function foo() { return {yield} }", {
                                         "end": 30,
                                         "name": "yield"
                                     },
-                                    "kind": "init",
                                     "value": {
                                         "type": "Identifier",
                                         "start": 25,
                                         "end": 30,
                                         "name": "yield"
-                                    }
+                                    },
+                                    "kind": "init"
                                 }
                             ]
                         }
@@ -15623,7 +15623,6 @@ test("({*yield() {}})", {
                             "end": 8,
                             "name": "yield"
                         },
-                        "kind": "init",
                         "value": {
                             "type": "FunctionExpression",
                             "start": 8,
@@ -15638,7 +15637,8 @@ test("({*yield() {}})", {
                                 "end": 13,
                                 "body": []
                             }
-                        }
+                        },
+                        "kind": "init"
                     }
                 ]
             }
@@ -15842,7 +15842,6 @@ test("function* foo(a = {*bar() { yield b }}) {}", {
                   "end": 23,
                   "name": "bar"
                 },
-                "kind": "init",
                 "value": {
                   "type": "FunctionExpression",
                   "start": 23,
@@ -15875,7 +15874,8 @@ test("function* foo(a = {*bar() { yield b }}) {}", {
                       }
                     ]
                   }
-                }
+                },
+                "kind": "init"
               }
             ]
           }
@@ -16104,7 +16104,6 @@ test("function* wrap() {\n({a = yield b} = obj)\n}", {
                       "end": 22,
                       "name": "a"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "AssignmentPattern",
                       "start": 21,
@@ -16127,7 +16126,8 @@ test("function* wrap() {\n({a = yield b} = obj)\n}", {
                           "name": "b"
                         }
                       }
-                    }
+                    },
+                    "kind": "init"
                   }
                 ]
               },
@@ -16640,7 +16640,6 @@ test("const myFn = ({ set = '' }) => {};", {
                       "type": "Identifier",
                       "name": "set"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "AssignmentPattern",
                       "left": {
@@ -16651,7 +16650,8 @@ test("const myFn = ({ set = '' }) => {};", {
                         "type": "Literal",
                         "value": ""
                       }
-                    }
+                    },
+                    "kind": "init"
                   }
                 ]
               }

--- a/test/tests-rest-spread-properties.js
+++ b/test/tests-rest-spread-properties.js
@@ -139,13 +139,13 @@ test("({a,...obj1,b:1,...obj2,c:2})", {
               "end": 3,
               "name": "a"
             },
-            "kind": "init",
             "value": {
               "type": "Identifier",
               "start": 2,
               "end": 3,
               "name": "a"
-            }
+            },
+            "kind": "init"
           },
           {
             "type": "SpreadElement",
@@ -288,13 +288,13 @@ test("({...a,b,c})", {
               "end": 8,
               "name": "b"
             },
-            "kind": "init",
             "value": {
               "type": "Identifier",
               "start": 7,
               "end": 8,
               "name": "b"
-            }
+            },
+            "kind": "init"
           },
           {
             "type": "Property",
@@ -309,13 +309,13 @@ test("({...a,b,c})", {
               "end": 10,
               "name": "c"
             },
-            "kind": "init",
             "value": {
               "type": "Identifier",
               "start": 9,
               "end": 10,
               "name": "c"
-            }
+            },
+            "kind": "init"
           }
         ]
       }
@@ -374,13 +374,13 @@ test("({...(a,b),c})", {
               "end": 12,
               "name": "c"
             },
-            "kind": "init",
             "value": {
               "type": "Identifier",
               "start": 11,
               "end": 12,
               "name": "c"
-            }
+            },
+            "kind": "init"
           }
         ]
       }
@@ -471,13 +471,13 @@ test("({a,...obj} = foo)", {
                 "end": 3,
                 "name": "a"
               },
-              "kind": "init",
               "value": {
                 "type": "Identifier",
                 "start": 2,
                 "end": 3,
                 "name": "a"
-              }
+              },
+              "kind": "init"
             },
             {
               "type": "RestElement",
@@ -710,13 +710,13 @@ test("({a,...obj}) => {}", {
                   "end": 3,
                   "name": "a"
                 },
-                "kind": "init",
                 "value": {
                   "type": "Identifier",
                   "start": 2,
                   "end": 3,
                   "name": "a"
-                }
+                },
+                "kind": "init"
               },
               {
                 "type": "RestElement",
@@ -1289,13 +1289,13 @@ test("let {x, ...y} = v", {
                   "end": 6,
                   "name": "x"
                 },
-                "kind": "init",
                 "value": {
                   "type": "Identifier",
                   "start": 5,
                   "end": 6,
                   "name": "x"
-                }
+                },
+                "kind": "init"
               },
               {
                 "type": "RestElement",
@@ -1358,13 +1358,13 @@ test("(function({x, ...y}) {})", {
                   "end": 12,
                   "name": "x"
                 },
-                "kind": "init",
                 "value": {
                   "type": "Identifier",
                   "start": 11,
                   "end": 12,
                   "name": "x"
-                }
+                },
+                "kind": "init"
               },
               {
                 "type": "RestElement",
@@ -1437,7 +1437,6 @@ test("const fn = ({text = \"default\", ...props}) => text + props.children", {
                       "end": 17,
                       "name": "text"
                     },
-                    "kind": "init",
                     "value": {
                       "type": "AssignmentPattern",
                       "start": 13,
@@ -1455,7 +1454,8 @@ test("const fn = ({text = \"default\", ...props}) => text + props.children", {
                         "value": "default",
                         "raw": "\"default\""
                       }
-                    }
+                    },
+                    "kind": "init"
                   },
                   {
                     "type": "RestElement",

--- a/test/tests-trailing-commas-in-func.js
+++ b/test/tests-trailing-commas-in-func.js
@@ -182,7 +182,6 @@ test("({foo(a,) {}})", {
               "end": 5,
               "name": "foo"
             },
-            "kind": "init",
             "value": {
               "type": "FunctionExpression",
               "start": 5,
@@ -205,7 +204,8 @@ test("({foo(a,) {}})", {
                 "end": 12,
                 "body": []
               }
-            }
+            },
+            "kind": "init"
           }
         ]
       }


### PR DESCRIPTION
Follow on after #1347. Update the tests to have `kind` field of `Property` last in all cases.

This makes no actual difference, as the tests don't check for field order. But it makes sense for the test cases to correspond to actual output, and will avoid spurious errors if the tests do in future check field order.

Sorry, I should have included this in #1347.
