### PR TITLE
define extra interface for extending AnyNode type

### DIFF
--- a/acorn/src/acorn.d.ts
+++ b/acorn/src/acorn.d.ts
@@ -585,11 +585,11 @@ export type ModuleDeclaration =
   * }
   * ```
   */
-interface AllNodesRecord {
-  Default: Statement | Expression | Declaration | ModuleDeclaration | Literal | Program | SwitchCase | CatchClause | Property | Super | SpreadElement | TemplateElement | AssignmentProperty | ObjectPattern | ArrayPattern | RestElement | AssignmentPattern | ClassBody | MethodDefinition | MetaProperty | ImportAttribute | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier | AnonymousFunctionDeclaration | AnonymousClassDeclaration | PropertyDefinition | PrivateIdentifier | StaticBlock | VariableDeclarator;
+interface NodeTypes {
+  core: Statement | Expression | Declaration | ModuleDeclaration | Literal | Program | SwitchCase | CatchClause | Property | Super | SpreadElement | TemplateElement | AssignmentProperty | ObjectPattern | ArrayPattern | RestElement | AssignmentPattern | ClassBody | MethodDefinition | MetaProperty | ImportAttribute | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier | AnonymousFunctionDeclaration | AnonymousClassDeclaration | PropertyDefinition | PrivateIdentifier | StaticBlock | VariableDeclarator
 }
 
-export type AnyNode = AllNodesRecord[keyof AllNodesRecord];
+export type AnyNode = NodeTypes[keyof NodeTypes]
 
 export function parse(input: string, options: Options): Program
 

--- a/acorn/src/acorn.d.ts
+++ b/acorn/src/acorn.d.ts
@@ -579,8 +579,8 @@ export type ModuleDeclaration =
   * @example 
   * ```typescript
   * declare module 'acorn' {
-  *   interface AllNodesRecord {
-  *     PluginName: FirstNode | SecondNode | ThirdNode | ... | LastNode;
+  *   interface NodeTypes {
+  *     pluginName: FirstNode | SecondNode | ThirdNode | ... | LastNode;
   *   }
   * }
   * ```

--- a/acorn/src/acorn.d.ts
+++ b/acorn/src/acorn.d.ts
@@ -572,7 +572,24 @@ export type ModuleDeclaration =
 | ExportDefaultDeclaration
 | ExportAllDeclaration
 
-export type AnyNode = Statement | Expression | Declaration | ModuleDeclaration | Literal | Program | SwitchCase | CatchClause | Property | Super | SpreadElement | TemplateElement | AssignmentProperty | ObjectPattern | ArrayPattern | RestElement | AssignmentPattern | ClassBody | MethodDefinition | MetaProperty | ImportAttribute | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier | AnonymousFunctionDeclaration | AnonymousClassDeclaration | PropertyDefinition | PrivateIdentifier | StaticBlock | VariableDeclarator
+/**
+  * This interface is only used for defining {@link AnyNode}. 
+  * It exists so that it can be extended by plugins:
+  *
+  * @example 
+  * ```typescript
+  * declare module 'acorn' {
+  *   interface AllNodesRecord {
+  *     PluginName: FirstNode | SecondNode | ThirdNode | ... | LastNode;
+  *   }
+  * }
+  * ```
+  */
+interface AllNodesRecord {
+  Default: Statement | Expression | Declaration | ModuleDeclaration | Literal | Program | SwitchCase | CatchClause | Property | Super | SpreadElement | TemplateElement | AssignmentProperty | ObjectPattern | ArrayPattern | RestElement | AssignmentPattern | ClassBody | MethodDefinition | MetaProperty | ImportAttribute | ImportSpecifier | ImportDefaultSpecifier | ImportNamespaceSpecifier | ExportSpecifier | AnonymousFunctionDeclaration | AnonymousClassDeclaration | PropertyDefinition | PrivateIdentifier | StaticBlock | VariableDeclarator;
+}
+
+export type AnyNode = AllNodesRecord[keyof AllNodesRecord];
 
 export function parse(input: string, options: Options): Program
 


### PR DESCRIPTION
This defines the `AnyNode` type union from an interface, so that it can be extended by

```typescript
declare module 'acorn' {
  interface NodeTypes {
    pluginName: FirstNode | SecondNode | ThirdNode | ... | LastNode;
  }
}
```

This allows it so that `acorn-walk`, and any other function/interface using `AnyNode` are extended depending on the plugins used. The change could also've been to the Program type so that it could have the Nodes that can then propagate to other functions, but that might be way too complex.