### PR TITLE
fix: raises syntax errors on invalid `using` declarations

### DIFF
--- a/acorn/src/scopeflags.js
+++ b/acorn/src/scopeflags.js
@@ -10,6 +10,7 @@ export const
     SCOPE_DIRECT_SUPER = 128,
     SCOPE_CLASS_STATIC_BLOCK = 256,
     SCOPE_CLASS_FIELD_INIT = 512,
+    SCOPE_SWITCH = 1024,
     SCOPE_VAR = SCOPE_TOP | SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK
 
 export function functionFlags(async, generator) {

--- a/acorn/src/state.js
+++ b/acorn/src/state.js
@@ -5,7 +5,7 @@ import {getOptions} from "./options.js"
 import {wordsRegexp} from "./util.js"
 import {
   SCOPE_TOP, SCOPE_FUNCTION, SCOPE_ASYNC, SCOPE_GENERATOR, SCOPE_SUPER, SCOPE_DIRECT_SUPER,
-  SCOPE_ARROW, SCOPE_CLASS_STATIC_BLOCK, SCOPE_CLASS_FIELD_INIT
+  SCOPE_ARROW, SCOPE_CLASS_STATIC_BLOCK, SCOPE_CLASS_FIELD_INIT, SCOPE_SWITCH
 } from "./scopeflags.js"
 
 export class Parser {
@@ -113,6 +113,13 @@ export class Parser {
       if (flags & SCOPE_FUNCTION) return (flags & SCOPE_ASYNC) > 0
     }
     return (this.inModule && this.options.ecmaVersion >= 13) || this.options.allowAwaitOutsideFunction
+  }
+
+  get canUsing() {
+    let {flags} = this.currentScope()
+    if (flags & SCOPE_SWITCH) return false
+    if (!this.inModule && flags & SCOPE_TOP) return false
+    return true
   }
 
   get allowSuper() {

--- a/acorn/src/state.js
+++ b/acorn/src/state.js
@@ -115,13 +115,6 @@ export class Parser {
     return (this.inModule && this.options.ecmaVersion >= 13) || this.options.allowAwaitOutsideFunction
   }
 
-  get canUsing() {
-    let {flags} = this.currentScope()
-    if (flags & SCOPE_SWITCH) return false
-    if (!this.inModule && flags & SCOPE_TOP) return false
-    return true
-  }
-
   get allowSuper() {
     const {flags} = this.currentThisScope()
     return (flags & SCOPE_SUPER) > 0 || this.options.allowSuperOutsideMethod
@@ -138,6 +131,13 @@ export class Parser {
           ((flags & SCOPE_FUNCTION) && !(flags & SCOPE_ARROW))) return true
     }
     return false
+  }
+
+  get allowUsing() {
+    const {flags} = this.currentScope()
+    if (flags & SCOPE_SWITCH) return false
+    if (!this.inModule && flags & SCOPE_TOP) return false
+    return true
   }
 
   get inClassStaticBlock() {

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -194,7 +194,7 @@ pp.parseStatement = function(context, topLevel, exports) {
 
     let usingKind = this.isAwaitUsing(false) ? "await using" : this.isUsing(false) ? "using" : null
     if (usingKind) {
-      if (!this.canUsing) {
+      if (!this.allowUsing) {
         this.raise(this.start, "Using declaration cannot appear in the top level when source type is `script` or in the bare case statement")
       }
       if (usingKind === "await using") {

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -4,7 +4,7 @@ import {lineBreak, skipWhiteSpace} from "./whitespace.js"
 import {isIdentifierStart, isIdentifierChar, keywordRelationalOperator} from "./identifier.js"
 import {hasOwn, loneSurrogate} from "./util.js"
 import {DestructuringErrors} from "./parseutil.js"
-import {functionFlags, SCOPE_SIMPLE_CATCH, BIND_SIMPLE_CATCH, BIND_LEXICAL, BIND_VAR, BIND_FUNCTION, SCOPE_CLASS_STATIC_BLOCK, SCOPE_SUPER, SCOPE_CLASS_FIELD_INIT} from "./scopeflags.js"
+import {functionFlags, SCOPE_SIMPLE_CATCH, BIND_SIMPLE_CATCH, BIND_LEXICAL, BIND_VAR, BIND_FUNCTION, SCOPE_CLASS_STATIC_BLOCK, SCOPE_SUPER, SCOPE_CLASS_FIELD_INIT, SCOPE_SWITCH} from "./scopeflags.js"
 
 const pp = Parser.prototype
 
@@ -194,8 +194,8 @@ pp.parseStatement = function(context, topLevel, exports) {
 
     let usingKind = this.isAwaitUsing(false) ? "await using" : this.isUsing(false) ? "using" : null
     if (usingKind) {
-      if (topLevel && this.options.sourceType === "script") {
-        this.raise(this.start, "Using declaration cannot appear in the top level when source type is `script`")
+      if (!this.canUsing) {
+        this.raise(this.start, "Using declaration cannot appear in the top level when source type is `script` or in the bare case statement")
       }
       if (usingKind === "await using") {
         if (!this.canAwait) {
@@ -292,7 +292,12 @@ pp.parseForStatement = function(node) {
   if (usingKind) {
     let init = this.startNode()
     this.next()
-    if (usingKind === "await using") this.next()
+    if (usingKind === "await using") {
+      if (!this.canAwait) {
+        this.raise(this.start, "Await using cannot appear outside of async function")
+      }
+      this.next()
+    }
     this.parseVar(init, true, usingKind)
     this.finishNode(init, "VariableDeclaration")
     return this.parseForAfterInit(node, init, awaitAt)
@@ -370,7 +375,7 @@ pp.parseSwitchStatement = function(node) {
   node.cases = []
   this.expect(tt.braceL)
   this.labels.push(switchLabel)
-  this.enterScope(0)
+  this.enterScope(SCOPE_SWITCH)
 
   // Statements under must be grouped (by label) in SwitchCase
   // nodes. `cur` is used to keep the node that we are currently

--- a/bin/test262.whitelist
+++ b/bin/test262.whitelist
@@ -1,0 +1,4 @@
+staging/explicit-resource-management/await-using-in-switch-case-block.js (default)
+staging/explicit-resource-management/await-using-in-switch-case-block.js (strict mode)
+staging/explicit-resource-management/call-dispose-methods.js (default)
+staging/explicit-resource-management/call-dispose-methods.js (strict mode)

--- a/test/tests-using.js
+++ b/test/tests-using.js
@@ -1102,14 +1102,14 @@ testFail("let await using x = resource;", "Cannot use keyword 'await' outside an
 // let using is not allowed
 testFail("let using x = resource;", "Unexpected token (1:10)", {ecmaVersion: 17, sourceType: "module"});
 // top level using is not allowed
-testFail("using x = resource;", "Using declaration cannot appear in the top level when source type is `script` (1:0)", {ecmaVersion: 17, sourceType: "script"});
+testFail("using x = resource;", "Using declaration cannot appear in the top level when source type is `script` or in the bare case statement (1:0)", {ecmaVersion: 17, sourceType: "script"});
 
 // BoundNames contains "let"  
 testFail("async function test() { await using let = resource; }", "The keyword 'let' is reserved (1:36)", {ecmaVersion: 17, sourceType: "module"});
 // BoundNames contains duplicate entries
 testFail("async function test() { await using x = resource1, x = resource2; }", "Identifier 'x' has already been declared (1:51)", {ecmaVersion: 17, sourceType: "module"});
 // top level await using is not allowed
-testFail("await using x = resource;", "Using declaration cannot appear in the top level when source type is `script` (1:0)", {ecmaVersion: 17, sourceType: "script"});
+testFail("await using x = resource;", "Using declaration cannot appear in the top level when source type is `script` or in the bare case statement (1:0)", {ecmaVersion: 17, sourceType: "script"});
 
 // Basic missing initializer
 testFail("{ using x; }", "Missing initializer in using declaration (1:9)", {ecmaVersion: 17, sourceType: "module"});
@@ -1178,6 +1178,11 @@ testFail("{ using \\u0030x = resource; }", "Invalid Unicode escape (1:8)", {ecma
 
 // await using in script mode
 testFail("{await using a = x}", "Await using cannot appear outside of async function (1:1)", {ecmaVersion: 17, sourceType: "script"});
+testFail("for (await using a of x) {}", "Await using cannot appear outside of async function (1:11)", {ecmaVersion: 17, sourceType: "script"});
+
+// Using in a bare case statement (should not be allowed)
+testFail("switch (x) { case 1: using y = resource; }", "Using declaration cannot appear in the top level when source type is `script` or in the bare case statement (1:21)", {ecmaVersion: 17, sourceType: "module"});
+testFail("switch (x) { case 1: break; default: using y = resource; }", "Using declaration cannot appear in the top level when source type is `script` or in the bare case statement (1:37)", {ecmaVersion: 17, sourceType: "module"});
 
 // =============================================================================
 // EDGE CASES - Unusual but valid scenarios and boundary conditions


### PR DESCRIPTION
This PR fixes the parser so that some invalid using declarations are now syntax errors rather than being allowed.

e.g. 

- ```js
  for (await using a of x) {} // in "script"
  ```
  This seems to be a missed test.

- ```js
  switch (x) { case 1: using y = resource; }
  ```
  It seems that the specifications have changed since we implemented it.
  https://github.com/rbuckton/ecma262/pull/14

