### PR TITLE
fix: Reject return statement in static block, even if allowReturnOutsideFunction is used

### DIFF
--- a/acorn/src/state.js
+++ b/acorn/src/state.js
@@ -115,6 +115,12 @@ export class Parser {
     return (this.inModule && this.options.ecmaVersion >= 13) || this.options.allowAwaitOutsideFunction
   }
 
+  get allowReturn() {
+    if (this.inFunction) return true
+    if (this.options.allowReturnOutsideFunction && this.currentVarScope().flags & SCOPE_TOP) return true
+    return false
+  }
+
   get allowSuper() {
     const {flags} = this.currentThisScope()
     return (flags & SCOPE_SUPER) > 0 || this.options.allowSuperOutsideMethod

--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -356,7 +356,7 @@ pp.parseIfStatement = function(node) {
 }
 
 pp.parseReturnStatement = function(node) {
-  if (!this.inFunction && !this.options.allowReturnOutsideFunction)
+  if (!this.allowReturn)
     this.raise(this.start, "'return' outside of function")
   this.next()
 

--- a/test/tests-class-features-2022.js
+++ b/test/tests-class-features-2022.js
@@ -6391,3 +6391,5 @@ testFail(`class C {
     return #brand in #brand in obj;
   }
 }`, 'Private identifier can only be left side of binary expression (5:21)', { ecmaVersion: 13 })
+
+testFail(`class X { static { return; } }`, "'return' outside of function (1:19)", {allowReturnOutsideFunction: true, ecmaVersion: 13});


### PR DESCRIPTION
This PR fixes the parser to reject return statements inside static blocks, even if `allowReturnOutsideFunction` is used.

Specifically, it rejects return statements like the following:

```js
class X {
  static {
    return;
  }
}
```

We found this issue while working on commonjs support.
https://github.com/acornjs/acorn/issues/1376#issuecomment-2963802684