### PR TITLE
Fix await using double lookahead edge case

### DIFF
--- a/acorn/src/statement.js
+++ b/acorn/src/statement.js
@@ -87,8 +87,8 @@ pp.isUsingKeyword = function(isAwaitUsing, isFor) {
     let usingEndPos = next + 5 /* using */, after
     if (this.input.slice(next, usingEndPos) !== "using" ||
       usingEndPos === this.input.length ||
-      isIdentifierChar(after = this.input.charCodeAt(usingEndPos)) ||
-      (after > 0xd7ff && after < 0xdc00)
+      isIdentifierChar(after = this.fullCharCodeAt(usingEndPos)) ||
+      after === 92 /* '\' */
     ) return false
 
     skipWhiteSpace.lastIndex = usingEndPos

--- a/test/tests-using.js
+++ b/test/tests-using.js
@@ -1184,6 +1184,9 @@ testFail("for (await using a of x) {}", "Await using cannot appear outside of as
 testFail("switch (x) { case 1: using y = resource; }", "Using declaration cannot appear in the top level when source type is `script` or in the bare case statement (1:21)", {ecmaVersion: 17, sourceType: "module"});
 testFail("switch (x) { case 1: break; default: using y = resource; }", "Using declaration cannot appear in the top level when source type is `script` or in the bare case statement (1:37)", {ecmaVersion: 17, sourceType: "module"});
 
+// await using double lookahead should detect using keyword correctly
+testFail("async () => { await using\\u0061 b = c }", "Unexpected token (1:32)", {ecmaVersion: 17, sourceType: "module"});
+
 // =============================================================================
 // EDGE CASES - Unusual but valid scenarios and boundary conditions
 // =============================================================================


### PR DESCRIPTION
In the double lookahead to determine whether it's an await using declaration, the check for the `using` keyword is not correct. Adding a Unicode escaped identifier character fools the parser logic:

`async () => { await using\\u0061 b = c }`

This incorrectly parses without an error.

I made an attempt at fixing the issue. (This way we should be consistent with the `readWord1` function of the tokenizer.)

BTW, it seems like there are similar issues here:
* https://github.com/acornjs/acorn/blob/ad66d004f28bc2d52b395b57c591d4b1608d1c9e/acorn/src/statement.js#L73
* https://github.com/acornjs/acorn/blob/ad66d004f28bc2d52b395b57c591d4b1608d1c9e/acorn/src/statement.js#L45