### PR TITLE
Tokenize a regexp after await in an async function (fixes #989)

### DIFF
--- a/acorn/src/tokencontext.js
+++ b/acorn/src/tokencontext.js
@@ -7,12 +7,13 @@ import {types as tt} from "./tokentype.js"
 import {lineBreak} from "./whitespace.js"
 
 export class TokContext {
-  constructor(token, isExpr, preserveSpace, override, generator) {
+  constructor(token, isExpr, preserveSpace, override, generator, async) {
     this.token = token
     this.isExpr = !!isExpr
     this.preserveSpace = !!preserveSpace
     this.override = override
     this.generator = !!generator
+    this.async = !!async
   }
 }
 
@@ -26,7 +27,11 @@ export const types = {
   f_stat: new TokContext("function", false),
   f_expr: new TokContext("function", true),
   f_expr_gen: new TokContext("function", true, false, null, true),
-  f_gen: new TokContext("function", false, false, null, true)
+  f_gen: new TokContext("function", false, false, null, true),
+  f_async_stat: new TokContext("function", false, false, null, false, true),
+  f_async_expr: new TokContext("function", true, false, null, false, true),
+  f_async_expr_gen: new TokContext("function", true, false, null, true, true),
+  f_async_gen: new TokContext("function", false, false, null, true, true)
 }
 
 const pp = Parser.prototype
@@ -41,7 +46,8 @@ pp.curContext = function() {
 
 pp.braceIsBlock = function(prevType) {
   let parent = this.curContext()
-  if (parent === types.f_expr || parent === types.f_stat)
+  if (parent === types.f_expr || parent === types.f_stat ||
+      parent === types.f_async_expr || parent === types.f_async_stat)
     return true
   if (prevType === tt.colon && (parent === types.b_stat || parent === types.b_expr))
     return !parent.isExpr
@@ -65,6 +71,15 @@ pp.inGeneratorContext = function() {
     let context = this.context[i]
     if (context.token === "function")
       return context.generator
+  }
+  return false
+}
+
+pp.inAsyncContext = function() {
+  for (let i = this.context.length - 1; i >= 1; i--) {
+    let context = this.context[i]
+    if (context.token === "function")
+      return context.async
   }
   return false
 }
@@ -122,13 +137,16 @@ tt.incDec.updateContext = function() {
 }
 
 tt._function.updateContext = tt._class.updateContext = function(prevType) {
+  let isAsync = prevType === tt.name &&
+    this.input.slice(this.lastTokStart, this.lastTokEnd) === "async" &&
+    !lineBreak.test(this.input.slice(this.lastTokEnd, this.start))
   if (prevType.beforeExpr && prevType !== tt._else &&
       !(prevType === tt.semi && this.curContext() !== types.p_stat) &&
       !(prevType === tt._return && lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) &&
       !((prevType === tt.colon || prevType === tt.braceL) && this.curContext() === types.b_stat))
-    this.context.push(types.f_expr)
+    this.context.push(isAsync ? types.f_async_expr : types.f_expr)
   else
-    this.context.push(types.f_stat)
+    this.context.push(isAsync ? types.f_async_stat : types.f_stat)
   this.exprAllowed = false
 }
 
@@ -150,6 +168,10 @@ tt.star.updateContext = function(prevType) {
     let index = this.context.length - 1
     if (this.context[index] === types.f_expr)
       this.context[index] = types.f_expr_gen
+    else if (this.context[index] === types.f_async_expr)
+      this.context[index] = types.f_async_expr_gen
+    else if (this.context[index] === types.f_async_stat)
+      this.context[index] = types.f_async_gen
     else
       this.context[index] = types.f_gen
   }
@@ -160,7 +182,8 @@ tt.name.updateContext = function(prevType) {
   let allowed = false
   if (this.options.ecmaVersion >= 6 && prevType !== tt.dot) {
     if (this.value === "of" && !this.exprAllowed ||
-        this.value === "yield" && this.inGeneratorContext())
+        this.value === "yield" && this.inGeneratorContext() ||
+        this.value === "await" && this.inAsyncContext())
       allowed = true
   }
   this.exprAllowed = allowed

--- a/test/run.js
+++ b/test/run.js
@@ -4,6 +4,7 @@
   require("./tests-harmony.js");
   require("./tests-es7.js");
   require("./tests-asyncawait.js");
+  require("./tests-tokenizer.js");
   require("./tests-await-top-level.js");
   require("./tests-trailing-commas-in-func.js");
   require("./tests-template-literal-revision.js");

--- a/test/tests-tokenizer.js
+++ b/test/tests-tokenizer.js
@@ -1,0 +1,44 @@
+// Tests for the standalone tokenizer (acorn.tokenizer()), which decides
+// regexp-vs-division from the token context state machine rather than from
+// the parser's grammar state, so it is exercised separately here.
+
+if (typeof exports !== "object") throw new Error("This file must be run in Node")
+
+var acorn = require("../acorn")
+var driver = require("./driver.js")
+
+function tokenTypes(code, options) {
+  var types = [], tokenizer = acorn.tokenizer(code, Object.assign({ecmaVersion: 2022}, options)), token
+  do {
+    token = tokenizer.getToken()
+    types.push(token.type.label)
+  } while (token.type !== acorn.tokTypes.eof)
+  return types
+}
+
+function tokenizesRegexp(code, options) {
+  try {
+    return tokenTypes(code, options).indexOf("regexp") > -1
+  } catch (e) {
+    return false
+  }
+}
+
+var opts = {ecmaVersion: 2022}
+
+// A slash right after a name is division; the tokenizer must not read it as a regexp.
+driver.testAssert("function f() { a / b }", function() {
+  return tokenizesRegexp("function f() { a / b }") ? "expected division, not a regexp" : null
+}, opts)
+
+// A regexp is allowed after yield in a generator and after await in an async
+// function; the tokenizer must recognize both.
+driver.testAssert("function* f() { yield /a*/ }", function() {
+  return tokenizesRegexp("function* f() { yield /a*/ }") ? null : "expected a regexp after yield"
+}, opts)
+driver.testAssert("async function f() { await /a*/ }", function() {
+  return tokenizesRegexp("async function f() { await /a*/ }") ? null : "expected a regexp after await"
+}, opts)
+driver.testAssert("async function* f() { await /a*/ }", function() {
+  return tokenizesRegexp("async function* f() { await /a*/ }") ? null : "expected a regexp after await"
+}, opts)


### PR DESCRIPTION
Fixes #989.

The standalone tokenizer reads a regexp literal after `await` in an async function as division, so it throws where it should not:

```js
const acorn = require("acorn");
for (const t of acorn.tokenizer("async function f() { await /a*/ }", { ecmaVersion: 2022 })) {}
// Unterminated regular expression (1:30)
```

`acorn.parse` handles the same source, so only the tokenizer path (`acorn.tokenizer`, `acorn --tokenize`, the raw `onToken` stream) is affected, which breaks tools built on the token stream such as highlighters and linter token passes.

## Cause

`await` and `yield` are contextual and are emitted as `tt.name`, so the regexp-vs-division decision comes from `tt.name.updateContext`. That function sets `exprAllowed` after `of` and `yield` (via `inGeneratorContext()`) but had no case for `await`, and there was no async-function context to consult (the function `TokContext` tracked `generator` but not `async`). So the `/` after `await` was treated as division and the literal was never closed.

## Fix

Track async function contexts the same way generator contexts are already tracked: add an `async` flag to `TokContext`, add the four async function context singletons, mark the context async in `tt._function.updateContext` (using the preceding token, like the existing checks), preserve it across the `*` upgrade, add `inAsyncContext()` as the twin of `inGeneratorContext()`, and allow a regexp after `await` when in an async context. This mirrors the existing `yield`/generator machinery and follows the maintainer's suggestion in #989.

Consistent with the existing `yield` handling, this covers the `async function` / `async function*` forms (methods and arrows push no function context and remain division, exactly as `yield` behaves inside them today).

## Testing

Added `test/tests-tokenizer.js`, which drives `acorn.tokenizer()` directly (the parser-based driver cannot exercise the tokenizer state machine). It asserts a regexp is recognized after `await` in an async function and after `yield` in a generator, and that a slash after a plain name stays division. The `await` cases fail before this change and pass after; the full suite stays green.
