### PR TITLE
Reject an unparenthesized arrow function as the left operand of `**`

### DIFF
--- a/acorn/src/expression.js
+++ b/acorn/src/expression.js
@@ -269,7 +269,7 @@ pp.parseMaybeUnary = function(refDestructuringErrors, sawUnary, incDec, forInit)
     }
   }
 
-  if (!incDec && this.eat(tt.starstar)) {
+  if (!incDec && !(expr.type === "ArrowFunctionExpression" && expr.start === startPos) && this.eat(tt.starstar)) {
     if (sawUnary)
       this.unexpected(this.lastTokStart)
     else

--- a/test/tests-es7.js
+++ b/test/tests-es7.js
@@ -396,3 +396,9 @@ testFail(
 testFail("'use strict'; function y(x = 1) { 'use strict' }",
          "Illegal 'use strict' directive in function with non-simple parameter list (1:14)",
          {ecmaVersion: 7})
+
+// An unparenthesized arrow function cannot be the left operand of `**`:
+// its left operand must be an UpdateExpression, and an arrow function is an
+// AssignmentExpression, so `() => {} ** x` is a SyntaxError (matches V8).
+testFail("() => {} ** 2", "Unexpected token (1:9)", {ecmaVersion: 7})
+testFail("a => {} ** b", "Unexpected token (1:8)", {ecmaVersion: 7})


### PR DESCRIPTION
## What

An unparenthesized arrow function is accepted as the left operand of `**`:

```js
acorn.parse("() => {} ** 2", { ecmaVersion: "latest" })
// accepted -> BinaryExpression { operator: "**", left: ArrowFunctionExpression, right: Literal }
```

Per the grammar, `ExponentiationExpression : UpdateExpression ** ExponentiationExpression` — the left operand must be an `UpdateExpression` (which reduces to a `LeftHandSideExpression`). An `ArrowFunction` is an `AssignmentExpression`, never a `LeftHandSideExpression`, so `arrow ** x` is a **SyntaxError** unless the arrow is parenthesized. V8 and SpiderMonkey both reject `() => {} ** 2`; acorn accepts it and emits a `BinaryExpression` whose `.left` is an `ArrowFunctionExpression`, a shape no spec-compliant consumer expects.

## Root cause

`parseMaybeUnary` handles `**` directly (rather than through the precedence parser) and attaches it to whatever `expr` it just parsed, including a naked arrow function. The other places that could attach an operator to a naked arrow already guard against it — `parseExprOps` and `parseMaybeConditional` (the latter added in c2994ee for the ternary case, #1428). The `**` branch was the missing sibling, so operators routed through the precedence parser (`+`, `?:`, …) correctly reject after a naked arrow, but `**` did not.

## Fix

Apply the same `ArrowFunctionExpression && expr.start === startPos` guard before consuming `**`, so `**` falls through to the usual "Unexpected token" error. `(a => {}) ** b` and `a => a ** b` still parse.

## Tests

Added `testFail` cases in `test/tests-es7.js` for `() => {} ** 2` and `a => {} ** b`. They fail on the current parser (which accepts them) and pass with the fix; the full suite (13549 tests) stays green.
