### PR TITLE
Add missing isIdentifierStart / isIdentifierChar type declarations

### DIFF
--- a/acorn/src/acorn.d.ts
+++ b/acorn/src/acorn.d.ts
@@ -789,6 +789,10 @@ export const defaultOptions: Options
 
 export function getLineInfo(input: string, offset: number): Position
 
+export function isIdentifierStart(code: number, astral?: boolean): boolean
+
+export function isIdentifierChar(code: number, astral?: boolean): boolean
+
 export class TokenType {
   label: string
   keyword: string | undefined


### PR DESCRIPTION
Adds the missing `isIdentifierStart` and `isIdentifierChar` declarations
to `acorn/src/acorn.d.ts`. Both are exported at runtime from
`acorn/src/index.js` but absent from the type declarations, so TypeScript
consumers can't use them.

No runtime changes. Build and the full test suite pass locally.

Fixes #1260

---

Disclosure: this patch was generated by an AI agent pipeline I'm building,
and I reviewed it before opening. Happy to rework or close it if that's
not welcome here.
